### PR TITLE
docs(aimate): add test-pr-guide to README

### DIFF
--- a/plugins/aimate/README.md
+++ b/plugins/aimate/README.md
@@ -32,6 +32,16 @@ Performs comprehensive code review — identifies bugs, logic errors, security i
 
 ---
 
+### `test-pr-guide`
+
+> Produce a step-by-step manual testing guide for a branch or PR.
+
+Analyzes the diff, identifies what changed, and writes a guide a real person can follow to verify the feature or fix works — including setup requirements, test scenarios, and expected outcomes. Supports GitLab MR URLs and local branches.
+
+**Trigger phrases:** "how do I test this PR", "create a test plan", "write a QA checklist", "how do I test this MR"
+
+---
+
 ### `gitlab-mr-review` (Deprecated)
 
 > ⚠️ **Deprecated.** Use [`review-pr`](#review-pr) instead, which provides unified support for both GitHub and GitLab.


### PR DESCRIPTION
## Summary
- Adds missing `test-pr-guide` skill entry to `plugins/aimate/README.md`
- Skill was merged in #1 but README was not updated on main

## Test plan
- [ ] Verify `test-pr-guide` entry appears in plugin README
- [ ] Check trigger phrases are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)