### PR TITLE
feat: Testable acceptance criteria across the aimate skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Translate the problem into a structured Product Requirements Document with user 
 
 | Tool | Source | Purpose |
 |---|---|---|
-| `write-prd` | aimate | Interview-driven PRD creation with codebase exploration and component sketching |
+| `write-prd` | aimate | Interview-driven PRD creation with codebase exploration and component sketching; ends with a machine-readable acceptance-criteria block (`AC-<n>` ids) |
 | Figma MCP | aimate (bundled) | Inspect designs, read component specs, and pull design context directly into the PRD |
 | Atlassian MCP | aimate (bundled) | Read linked Jira issues for acceptance criteria and link the finished PRD back to the ticket |
 
@@ -289,10 +289,11 @@ Break down the spec into an atomic, dependency-mapped implementation plan with e
 
 ### Stage 5 — Implement
 
-Hand off the result of the scope-plan or spec to your team's coding agent. This stage is intentionally left to each project team — choose the coding agent, model, and project-specific skills that fit your stack.
+Scaffold tests from the spec's acceptance criteria first, then hand off the result of the scope-plan or spec to your team's coding agent. This stage is intentionally left to each project team — choose the coding agent, model, and project-specific skills that fit your stack.
 
 | Tool | Source | Purpose |
 |---|---|---|
+| `spec-to-tests` | aimate | Turn the PRD's acceptance-criteria block into failing test stubs in the project's test framework, one or more per `AC-<n>` id, ready to implement against |
 | Context7 MCP | [Recommended MCP](#context7-upstashcontext7) | Pull in up-to-date, version-specific library docs to prevent hallucinated APIs |
 | Figma MCP | aimate (bundled) | Reference component specs and design tokens when generating UI code |
 | GitLab MCP / Github MCP | aimate (bundled) | Create pull requests for changed code |
@@ -305,7 +306,7 @@ Review the resulting code changes for correctness, quality, and security. The Gi
 
 | Tool | Source | Purpose |
 |---|---|---|
-| `review-pr` | aimate | Comprehensive MR/PR review with inline comments and code fix suggestions — uses GitLab MCP to post directly on the MR |
+| `review-pr` | aimate | Comprehensive MR/PR review with inline comments and code fix suggestions — uses GitLab MCP to post directly on the MR. Also verifies the diff and its tests against the spec's acceptance criteria, reporting per `AC-<n>` id |
 | `asvs-audit` | aimate | OWASP ASVS 5.0 Level 1 security audit with evidence-backed findings |
 | GitLab MCP / Github | aimate (bundled) | Fetch MR diff, read existing comments, and post structured review comments |
 

--- a/plugins/aimate/README.md
+++ b/plugins/aimate/README.md
@@ -10,6 +10,12 @@ If you have the Superpowers plugin installed, be aware that it can sometimes int
 
 If a skill behaves inconsistently, invokes the wrong workflow, or appears to ignore its instructions, first check whether Superpowers was triggered in the workflow. If it was, disable or uninstall the Superpowers plugin and then rerun the skill.
 
+## Acceptance Criteria Contract
+
+`aimate` specs carry acceptance criteria in a single machine-readable format. Every PRD ends with an `## Acceptance Criteria` block where each criterion has a stable id (`AC-1`, `AC-2`, …) and states a condition and an expected outcome in Given/When/Then — structured data rather than prose buried in a user story.
+
+The id is the join key. `write-prd` writes the block, `spec-to-tests` turns each criterion into a test stub tagged with its id, and `review-pr` reports per id whether the change and its tests satisfy the criterion. The loop from spec to executable check holds because all three skills read and write one format, defined once in [`shared/acceptance-criteria.md`](shared/acceptance-criteria.md). An automated delivery pipeline reads the same block to get an objective definition of done.
+
 ## Skills
 
 ### `asvs-audit`
@@ -26,7 +32,7 @@ Conducts systematic security audits against all 70 OWASP ASVS 5.0 Level 1 requir
 
 > Review a GitLab Merge Request or GitHub Pull Request and provide findings, and post structured review comments with issue explanation plus code fixes.
 
-Performs comprehensive code review — identifies bugs, logic errors, security issues, and style violations. Posts structured inline comments with code fix suggestions directly on the MR.
+Performs comprehensive code review — identifies bugs, logic errors, security issues, and style violations. Posts structured inline comments with code fix suggestions directly on the MR. Also runs an acceptance-criteria verification pass: it locates the linked spec and reports, per `AC-<n>`, whether the diff and its tests satisfy each criterion.
 
 **Trigger phrases:** "review this MR", "review this merge request", "review the gitlab MR"
 
@@ -66,9 +72,19 @@ Produces a deterministic, execution-ready implementation plan with atomic tasks,
 
 > Create a PRD and user stories through user interview, codebase exploration, and component design.
 
-Guides you through building a complete Product Requirements Document by interviewing you about the problem, exploring the codebase, sketching major components, and writing the final PRD as a Markdown file.
+Guides you through building a complete Product Requirements Document by interviewing you about the problem, exploring the codebase, sketching major components, and writing the final PRD as a Markdown file. Every PRD ends with a machine-readable `## Acceptance Criteria` block (stable `AC-<n>` ids) in the shared canonical format, derived from the interview and confirmed with you.
 
 **Trigger phrases:** "write a PRD", "create a product requirements document", "write user stories", "plan a new feature"
+
+---
+
+### `spec-to-tests`
+
+> Turn the acceptance-criteria block of a PRD into failing test stubs in the repository's own test framework.
+
+Reads the `## Acceptance Criteria` block from a spec, detects the project's test framework (PHPUnit, Jest/Vitest, pytest, Go `testing`, and similar), and scaffolds one or more stubs per criterion. Each stub is tagged with its criterion id and encodes Given/When/Then as arrange/act/assert with a failing or pending assertion — a starting point to fill in, never a fabricated passing test.
+
+**Trigger phrases:** "generate tests from spec", "spec to tests", "scaffold tests from the prd"
 
 ---
 

--- a/plugins/aimate/plugin.json
+++ b/plugins/aimate/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aimate",
   "description": "AI Automation Teammate - SDLC Acceleration; reusable skills for security auditing, GitLab workflow automation, and development planning.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Dawn Technology",
     "url": "https://github.com/Dawn-Technology"
@@ -19,6 +19,9 @@
     "planning",
     "product-requirements-document",
     "user-stories",
+    "acceptance-criteria",
+    "spec-to-tests",
+    "testing",
     "estimation",
     "wbso",
     "wbso-aanvraag"

--- a/plugins/aimate/shared/acceptance-criteria.md
+++ b/plugins/aimate/shared/acceptance-criteria.md
@@ -1,0 +1,72 @@
+# Acceptance Criteria Format
+
+This file defines the single canonical format for acceptance criteria across the `aimate` plugin. It is the shared contract between the skills that produce a spec (`write-prd`), the skill that turns a spec into test stubs (`spec-to-tests`), and the skill that reviews a change against a spec (`review-pr`). Any automated delivery pipeline that consumes a Dawn spec reads the same format.
+
+There is one definition, and it lives here. Skills reference this file rather than restating the grammar. If the format changes, it changes here and every reader is updated in the same step.
+
+## Why a fixed format
+
+An acceptance criterion is the join between a requirement, its tests, and its review. When criteria are free prose, a human has to judge whether code matches intent. When they follow a fixed, addressable grammar, that judgement becomes a checkable result: a tool can extract each criterion, find the test that covers it, and report whether the change satisfies it. The format below is designed to be parsed without guessing.
+
+## Design goals
+
+- **Machine-parseable.** The block sits under a fixed heading and is wrapped in stable sentinel comments, so a parser can extract the exact region regardless of what surrounds it.
+- **Individually addressable.** Each criterion carries a stable id (`AC-1`, `AC-2`, …). The id is the join key across the spec, the tests, and the review findings.
+- **Behaviour-oriented.** Each criterion states a condition and an expected outcome. Given/When/Then is the default. It describes behaviour, never test code.
+- **Framework-agnostic.** The criteria say nothing about a test framework. Mapping to a framework happens later, in `spec-to-tests`.
+
+## The block
+
+Every spec ends with one acceptance-criteria block in exactly this shape:
+
+```markdown
+## Acceptance Criteria
+
+<!-- acceptance-criteria:start format=gwt/v1 -->
+
+### AC-1: Password reset link is emailed
+- **Given** a registered user with a valid email
+- **When** a password reset is requested
+- **Then** a reset link valid for 60 minutes is sent to that email
+
+### AC-2: Expired reset links are rejected
+- **Given** an expired reset link
+- **When** the user opens it
+- **Then** the request is rejected
+- **And** no password change occurs
+
+<!-- acceptance-criteria:end -->
+```
+
+## Grammar
+
+Read the rules as the contract a parser relies on.
+
+1. **Section heading.** The block is introduced by the exact line `## Acceptance Criteria`.
+2. **Sentinels.** The criteria are wrapped in `<!-- acceptance-criteria:start format=gwt/v1 -->` and `<!-- acceptance-criteria:end -->`. A consumer extracts the text between these two comments. The `format=gwt/v1` marker versions the grammar; bump it only when the grammar itself changes.
+3. **Criterion header.** Each criterion begins with `### AC-<n>: <title>`, where `<n>` is a positive integer and `<title>` is a short human label. The `AC-<n>` token is the id.
+4. **Criterion body.** Bulleted lines with bolded keywords:
+   - `**Given**` — zero or more preconditions. Use `**And**` for each additional precondition.
+   - `**When**` — the action. Use `**And**` for a compound action.
+   - `**Then**` — one or more expected outcomes. Use `**And**` for each additional outcome.
+   - A `**When**` and at least one `**Then**` are required. `**Given**` is optional.
+5. **Shorthand.** Where Given/When/Then is overkill, a single `- **When** <condition>, **then** <outcome>` line is acceptable. Keep one style within a single spec — do not mix full and shorthand criteria in the same block.
+
+## Id rules
+
+- Ids are stable and never reused. Once `AC-3` names a criterion, it names that criterion for the life of the spec.
+- Never renumber to close a gap. If a criterion is dropped, retire its id rather than shifting the others.
+- New criteria take the next unused integer.
+- The id is the join key. Tests reference it, review findings reference it, and any pipeline correlates spec, tests, and results through it.
+
+## Quality bar
+
+Each criterion must be checkable: a concrete condition and an observable outcome. If a criterion cannot be written as a condition and an outcome — for example "the page should feel fast" — that is a signal the requirement is still vague. Sharpen the requirement rather than writing a fuzzy criterion.
+
+Keep criteria small. One criterion asserts one behaviour. Split a criterion that hides several independent outcomes so each can be tested and reviewed on its own.
+
+## Readers of this file
+
+- [`write-prd`](../skills/write-prd/SKILL.md) writes this block into every PRD.
+- [`spec-to-tests`](../skills/spec-to-tests/SKILL.md) reads the block and generates one or more test stubs per criterion, each tagged with the criterion id.
+- [`review-pr`](../skills/review-pr/SKILL.md) reads the block and reports, per id, whether the change and its tests satisfy the criterion.

--- a/plugins/aimate/skills/review-pr/SKILL.md
+++ b/plugins/aimate/skills/review-pr/SKILL.md
@@ -3,7 +3,7 @@ name: review-pr
 description: Review a GitHub or GitLab Pull/Merge Request and provide findings, and post structured review comments with issue explanation plus code fixes. Use this skill when asked to review a GitHub Pull Request or GitLab Merge Request.
 metadata:
   author: "Martin Roest <martin.roest@dawn.tech>"
-  version: 4.2.2
+  version: 4.3.0
 ---
 
 # PR/MR Review Workflow Skill
@@ -16,6 +16,9 @@ The purpose of this skill is to provide constructive and comprehensive feedback 
 - **Maintainability**: Ensure code is readable, modular, and consistent with the existing architecture.
 - **Security**: Detect common security vulnerabilities and privacy risks. Validate against OWASP Top 10 where applicable.
 - **Education**: Provide explanations and context for suggested changes to help the author grow.
+- **Spec conformance**: Verify the change against the linked spec's acceptance criteria, by id, so "did we build what the spec asked" is a checkable result rather than an opinion.
+
+The review also runs an acceptance-criteria verification pass (Step 5) alongside the code-review lenses. It reads the shared canonical criteria format defined in [`../../shared/acceptance-criteria.md`](../../shared/acceptance-criteria.md) — the same block `write-prd` writes and `spec-to-tests` consumes — and reports, per `AC-<n>`, whether the diff and its tests satisfy the criterion.
 
 This workflow is **read-first** and **non-invasive**:
 
@@ -62,18 +65,19 @@ Retrieve all metadata needed for the review using the tools matching `provider`.
 
 - Fetch the PR details (title, description, source/target branches, author, labels, milestone, `base_sha`, `head_sha`).
 - Fetch existing PR review threads and comments.
-- Note: GitHub uses `base_sha` and `head_sha` for inline comment positioning in Step 7-A.
+- Note: GitHub uses `base_sha` and `head_sha` for inline comment positioning in Step 8-A.
 
 **GitLab**:
 
 - Fetch the MR details (title, description, source/target branches, author, labels, milestone, `base_sha`, `start_sha`, `head_sha`).
 - Fetch existing MR discussions and review threads.
-- Note: GitLab requires `base_sha`, `start_sha`, and `head_sha` in the diff position object in Step 7-A.
+- Note: GitLab requires `base_sha`, `start_sha`, and `head_sha` in the diff position object in Step 8-A.
 
 For **both providers**:
 
 - Note all open and resolved threads to avoid duplicate feedback and to verify whether previously requested changes have been addressed.
 - Note the description for stated intent, linked issues, and breaking-change flags.
+- **Locate the linked spec.** From the description and any linked issue, capture the ticket id and the path of the spec that defines this change. Dawn specs produced by `write-prd` live under `docs/spec/` and end with a machine-readable `## Acceptance Criteria` block. Record the spec path (or note that none was linked) — Step 5 uses it.
 
 ---
 
@@ -86,7 +90,7 @@ git fetch origin {source_branch}
 git worktree add .worktrees/pr-review-{pr_mr_number} {source_branch}
 ```
 
-Store `worktree_path = ".worktrees/pr-review-{pr_mr_number}"` for Steps 3–5. **Read-only enforced** — do not modify files in the worktree.
+Store `worktree_path = ".worktrees/pr-review-{pr_mr_number}"` for Steps 3–6. **Read-only enforced** — do not modify files in the worktree.
 
 ---
 
@@ -124,7 +128,29 @@ Store the subagent's full response as your **review baseline** for code analysis
 
 ---
 
-### Step 5 — Analyze & Classify Findings
+### Step 5 — Acceptance-Criteria Verification Pass
+
+This pass checks the change against the spec's acceptance criteria by id. It runs in addition to the code-review lenses in Step 6, not instead of them. Its output is a per-criterion verdict plus any findings it raises.
+
+1. **Load the criteria.** Using the spec path captured in Step 1, read the spec in the worktree and find the `## Acceptance Criteria` block between the `<!-- acceptance-criteria:start ... -->` and `<!-- acceptance-criteria:end -->` sentinels. Parse each `AC-<n>` and its Given/When/Then per the shared canonical format in [`../../shared/acceptance-criteria.md`](../../shared/acceptance-criteria.md). Read that file so you parse the block the way it is written.
+   - If no spec was linked, or the spec has no criteria block, do not fail the review. Record that criteria verification could not run and why, skip the per-criterion checks, and surface it as a gap in the Step 7 report.
+
+2. **Verify each criterion by id.** For every `AC-<n>`, determine two things from the diff and the surrounding worktree code:
+   - **Implementation:** does the change appear to satisfy the criterion's `**Then**` outcome given its `**When**`? Classify as satisfied, partially satisfied, not satisfied, or unclear, and cite the diff evidence.
+   - **Test coverage:** is there a test that references the criterion id (test name or comment containing `AC-<n>`) and that actually asserts the `**Then**` outcome? Open the test and read the assertion — do not treat its existence as coverage.
+
+3. **Raise findings.** A gap in criteria conformance is a finding, not a footnote. Using the finding schema in Step 6, raise a `request-for-change` finding when:
+   - a criterion has no corresponding test;
+   - a test references the criterion id but does not assert the outcome (for example it is still a `spec-to-tests` stub, is skipped/pending, or asserts something trivial);
+   - the diff does not appear to satisfy the criterion.
+
+   Reference the criterion id in every such finding (for example `spec:AC-3:no-test` or `spec:AC-3:not-asserted`) so it joins back to the spec and any generated tests.
+
+4. Carry the per-criterion verdicts and these findings forward. They are presented alongside the code-review findings in Step 7.
+
+---
+
+### Step 6 — Analyze & Classify Findings
 
 Evaluate the diff through these four lenses:
 
@@ -146,15 +172,16 @@ For each finding, capture these fields internally:
 
 ---
 
-### Step 6 — Review & Present Findings to the User
+### Step 7 — Review & Present Findings to the User
 
 Do a rubber-duck review and critique the findings before sharing. Resolve any issues that may arise from the review.
-Then present the grouped findings report to the user **before taking any action**.
+Then present the grouped findings report to the user **before taking any action**. The findings include both the code-review findings from Step 6 and the acceptance-criteria findings from Step 5.
 
 The report must include:
 
 - PR/MR title, source → target branch, author.
 - Findings totals per severity.
+- **Acceptance-criteria verification summary**: the spec that was checked (or a note that none was linked), and a per-criterion line referencing each `AC-<n>` id, its implementation verdict (satisfied / partially / not satisfied / unclear), and its test-coverage verdict (covered / not asserted / no test). If criteria verification could not run, state that here.
 - Findings ordered by severity, then file path.
 
 Render each finding in this format:
@@ -175,11 +202,11 @@ If there are no findings, state that explicitly and mention any residual testing
 
 ---
 
-### Step 7 — Execute Chosen Action (Only When Confirmed)
+### Step 8 — Execute Chosen Action (Only When Confirmed)
 
-Based on the user's instructions from Step 6, take the appropriate action. All sub-steps below branch on `provider`.
+Based on the user's instructions from Step 7, take the appropriate action. All sub-steps below branch on `provider`.
 
-#### 7-A: Post Comments
+#### 8-A: Post Comments
 
 Post all approved findings as visible inline comments on the PR/MR.
 
@@ -220,7 +247,7 @@ If comment submission or publication fails after some comments may already have 
   3. Publish only the still-pending drafts individually.
 - **Fallback**: If inline positioning fails (e.g., "Line is out of bounds"), fall back to a general MR discussion note using `mcp_gitlab_create_merge_request_discussion_note`, indicating the target file and line.
 
-#### 7-B: Approve
+#### 8-B: Approve
 
 If the user requests approval, confirm there are no unresolved security violations first. If there are, explicitly confirm the user wants to proceed despite the risks.
 
@@ -228,7 +255,7 @@ If the user requests approval, confirm there are no unresolved security violatio
 
 **GitLab**: Approve the MR using `mcp_gitlab_approve_merge_request`.
 
-#### 7-C: Request Changes
+#### 8-C: Request Changes
 
 Formally mark the PR/MR as requiring changes.
 
@@ -298,17 +325,17 @@ mutation requestChanges($projectPath: ID!, $iid: String!) {
 
 _Note: `mergeRequestRequestChanges` requires GitLab 17.10+. On older instances the mutation may not exist — inspect the `errors` array and inform the user if it fails._
 
-#### 7-D/E: Refine or Report Only
+#### 8-D/E: Refine or Report Only
 
-If the user wants no action taken, proceed to Step 8 — Cleanup. If they want to refine, discuss the findings, update them, and repeat Step 6.
+If the user wants no action taken, proceed to Step 9 — Cleanup. If they want to refine, discuss the findings, update them, and repeat Step 7.
 
 ---
 
-### Step 8 — Clean Up
+### Step 9 — Clean Up
 
-Prerequisite: Step 8 must never run in the same response as Step 6. Execute it only after Step 7 is complete, or after the user explicitly says to stop at reporting only.
+Prerequisite: Step 9 must never run in the same response as Step 7. Execute it only after Step 8 is complete, or after the user explicitly says to stop at reporting only.
 
-This step is always executed, regardless of which option was chosen in Step 6.
+This step is always executed, regardless of which option was chosen in Step 7.
 
 1. **Remove the git worktree with verification**:
 

--- a/plugins/aimate/skills/spec-to-tests/SKILL.md
+++ b/plugins/aimate/skills/spec-to-tests/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: spec-to-tests
+description: Read the acceptance-criteria block from a PRD or spec and scaffold failing test stubs in the repository's own test framework, one or more per criterion, each tagged with its criterion id. Use when the user wants to generate tests from a spec, scaffold tests from the PRD, or turn acceptance criteria into a test skeleton.
+metadata:
+  author: "Dawn Technology"
+  version: 1.0.0
+---
+
+# Spec to Tests
+
+## Purpose
+
+Turn the acceptance criteria in a spec into executable test stubs. Each criterion in the spec becomes at least one test stub in the repository's own test framework, tagged with the criterion id so the link between spec and test is traceable in both directions.
+
+The stubs are stubs. They lay down the arrange/act/assert structure and leave a failing or pending assertion for a human or a coding agent to complete. This skill never writes a passing test — a green suite for behaviour nobody has implemented is worse than no test at all.
+
+This skill reads the shared canonical acceptance-criteria format defined in [`../../shared/acceptance-criteria.md`](../../shared/acceptance-criteria.md). It does not define its own format. Read that file before parsing a spec.
+
+## Inputs
+
+- **Spec file** — a PRD produced by `write-prd`, or any spec that ends with an `## Acceptance Criteria` block in the shared format. If the user gives a path, use it. If not, look under `docs/spec/` and, if several specs exist, ask which one.
+
+## Workflow
+
+Follow the steps in order.
+
+### Step 1 — Locate and parse the acceptance-criteria block
+
+1. Open the spec file and find the `## Acceptance Criteria` block bounded by the `<!-- acceptance-criteria:start format=gwt/v1 -->` and `<!-- acceptance-criteria:end -->` sentinels.
+2. If the block is missing, stop and tell the user: the spec has no machine-readable acceptance criteria, so re-run `write-prd` to add one, or point this skill at a spec that has one.
+3. If the `format=` marker is a version this skill does not recognise, stop and report the mismatch rather than guessing at the grammar.
+4. Extract each criterion: its id (`AC-<n>`), title, and the Given/When/Then lines. Keep the id exactly as written — it is the join key you will stamp onto every stub.
+
+### Step 2 — Detect the test framework
+
+Inspect the repository rather than assuming. Do not proceed on a guess — the framework decides the file layout, naming, and assertion style of every stub. Look for these signals and settle on the framework the evidence supports:
+
+| Stack | Detection signals | Default framework | Test file convention |
+|-------|-------------------|-------------------|----------------------|
+| PHP | `composer.json`, `phpunit.xml` / `phpunit.xml.dist`; `pestphp/pest` in `composer.json` | PHPUnit (Pest if present) | `tests/`, `*Test.php` |
+| JavaScript / TypeScript | `package.json` dev deps `jest` or `vitest`; `jest.config.*`, `vitest.config.*` | Jest or Vitest (match what is installed) | `__tests__/` or `*.test.ts` / `*.spec.ts` next to source |
+| Python | `pyproject.toml`, `pytest.ini`, `setup.cfg` `[tool:pytest]`, a `tests/` dir | pytest | `tests/`, `test_*.py` |
+| Go | `go.mod` | `testing` (standard library) | `*_test.go` beside source |
+
+Confirm the choice against how the project already writes tests: find an existing test file and match its directory, naming, imports, and assertion style. Existing repo convention wins over the table default.
+
+**If no framework can be detected**, degrade gracefully. Do not silently pick one. State clearly what you looked for and did not find, and ask the user to name the framework and test directory. Offer to emit framework-neutral pseudocode stubs (arrange/act/assert as comments) as a fallback so the criteria are still captured.
+
+### Step 3 — Map criteria to stubs
+
+Map each criterion to at least one stub:
+
+- One criterion, one behaviour, at least one test stub. Split into several stubs when a criterion has multiple `**Then**` outcomes that are worth asserting independently.
+- Every stub carries its criterion id in a form the framework makes greppable — the test name and a comment both contain `AC-<n>`. This gives traceability in both directions: from a criterion you can find its tests, and from a test you can find its criterion.
+- Translate the criterion straight into structure: `**Given**` → arrange, `**When**` → act, `**Then**` → assert. Leave the arrange/act sections as clearly marked TODOs and the assert as a failing or pending assertion.
+
+Group stubs into files following the convention confirmed in Step 2. Name files after the feature or spec, not after this skill.
+
+### Step 4 — Generate the stubs
+
+Write each stub with the arrange/act/assert skeleton and an assertion that keeps the suite red. Prefer the framework's idiomatic "incomplete/pending" marker; where none exists, use an explicit failing assertion. Never leave a stub that passes.
+
+PHPUnit:
+
+```php
+/** @covers AC-1: Account balance is shown on the home screen */
+public function testAc1AccountBalanceIsShownOnHomeScreen(): void
+{
+    // Given a logged-in user
+    // TODO: arrange the logged-in user
+
+    // When the user opens the app
+    // TODO: act — open the app
+
+    // Then the account balance is displayed prominently on the home screen
+    $this->markTestIncomplete('AC-1 not yet implemented');
+}
+```
+
+Jest / Vitest:
+
+```ts
+// AC-1: Account balance is shown on the home screen
+test('AC-1 account balance is shown on the home screen', () => {
+  // Given a logged-in user
+  // TODO: arrange the logged-in user
+
+  // When the user opens the app
+  // TODO: act — open the app
+
+  // Then the account balance is displayed prominently on the home screen
+  throw new Error('AC-1 not yet implemented');
+});
+```
+
+pytest:
+
+```python
+def test_ac1_account_balance_is_shown_on_home_screen():
+    """AC-1: Account balance is shown on the home screen."""
+    # Given a logged-in user
+    # TODO: arrange the logged-in user
+
+    # When the user opens the app
+    # TODO: act — open the app
+
+    # Then the account balance is displayed prominently on the home screen
+    pytest.fail("AC-1 not yet implemented")
+```
+
+Go:
+
+```go
+// TestAC1AccountBalanceIsShownOnHomeScreen covers AC-1.
+func TestAC1AccountBalanceIsShownOnHomeScreen(t *testing.T) {
+	// Given a logged-in user
+	// TODO: arrange the logged-in user
+
+	// When the user opens the app
+	// TODO: act — open the app
+
+	// Then the account balance is displayed prominently on the home screen
+	t.Fatal("AC-1 not yet implemented")
+}
+```
+
+### Step 5 — Report
+
+After writing the files, report back:
+
+- The framework detected and the evidence that led to it.
+- Each file created or modified.
+- A mapping table of criterion id → test name(s) → file, so the user can see every criterion is covered by a stub.
+- The command to run the new tests, discovered from the project config. Note that they are expected to fail until implemented.
+
+## Guardrails
+
+- Never fabricate a passing test. Every generated stub must fail or report as incomplete until a human or agent implements it.
+- Never invent a criteria format. Read only the shared canonical block; if it is absent or a newer grammar version, stop and report.
+- Match the repository's existing test conventions over the table defaults.
+- Keep the criterion id verbatim across the spec, the test name, and the comment — it is the join key.

--- a/plugins/aimate/skills/write-prd/SKILL.md
+++ b/plugins/aimate/skills/write-prd/SKILL.md
@@ -4,8 +4,10 @@ description: Create a PRD and user stories through user interview, codebase expl
 metadata:
   author: "Martin Roest <martin.roest@dawn.tech>"
   based_on: "https://github.com/mattpocock/skills/blob/main/write-a-prd/SKILL.md"
-  version: 1.0.0
+  version: 1.1.0
 ---
+
+> **Output contract:** Every PRD ends with a machine-readable `## Acceptance Criteria` block in the shared canonical format defined in [`../../shared/acceptance-criteria.md`](../../shared/acceptance-criteria.md). Each criterion has a stable id (`AC-1`, `AC-2`, …) that `spec-to-tests` and `review-pr` use as the join key between the spec, its tests, and its review. Do not invent a second criteria format — read and write the shared one.
 
 ## Steps
 
@@ -23,7 +25,13 @@ A deep component (as opposed to a shallow component) is one which encapsulates a
 
 Check with the user that these components match their expectations. Check with the user which components they want tests written for.
 
-5. Once you have a complete understanding of the problem and solution, use the template below to write the PRD. Save the PRD as a Markdown file in the project's `docs/spec` folder to `<YYYY-MM-DD>-<feature-name>.md`. Check if folder exists. If not, create it. If file already exists, append a version number to the end of the file name (e.g. `2024-06-01-new-feature-v2.md`).
+5. Derive the acceptance criteria from the requirements you gathered in the interview. Turn the behaviour behind each user story into one or more concrete criteria in the shared canonical format defined in [`../../shared/acceptance-criteria.md`](../../shared/acceptance-criteria.md). Read that file before writing the block.
+
+Each criterion is a checkable condition and an observable outcome, given a stable id (`AC-1`, `AC-2`, …). Walk the user through the derived criteria and ask them to confirm each one, fill any gaps, and correct anything that does not match intent — the criteria must be real, not decorative.
+
+If a requirement cannot be expressed as a condition and an outcome, it is too vague to test. Push back and sharpen the requirement with the user rather than writing a fuzzy criterion. Keep each criterion small: one criterion asserts one behaviour.
+
+6. Once you have a complete understanding of the problem and solution, use the template below to write the PRD. Save the PRD as a Markdown file in the project's `docs/spec` folder to `<YYYY-MM-DD>-<feature-name>.md`. Check if folder exists. If not, create it. If file already exists, append a version number to the end of the file name (e.g. `2024-06-01-new-feature-v2.md`).
 
 ## Template
 
@@ -41,7 +49,11 @@ The solution to the problem, from the user's perspective.
 
 ## User Stories
 
-A LONG, sequentially numbered list of user stories including title, description, conversation/notes, acceptance criteria. Number each story with a unique, incrementing integer (1, 2, 3, …) — never restart numbering. Use the INVEST checklist to ensure each story is Independent, Negotiable, Valuable, Estimable, Small, and Testable. Follow the Given-When-Then format for acceptance criteria. Each user story description should be in the format of:
+A LONG, sequentially numbered list of user stories including title, description, conversation/notes, and the ids of the acceptance criteria that cover the story. Number each story with a unique, incrementing integer (1, 2, 3, …) — never restart numbering. Use the INVEST checklist to ensure each story is Independent, Negotiable, Valuable, Estimable, Small, and Testable.
+
+Do not restate the full criteria under each story. The full Given-When-Then criteria live once in the `## Acceptance Criteria` block (see below), which is the single source of truth. Each story lists the ids of the criteria that cover it, so the story and its criteria stay in sync. Every story must map to at least one criterion; if it maps to none, either the story is not testable or a criterion is missing.
+
+Each user story description should be in the format of:
 
 {N}. <Title>
 
@@ -56,9 +68,7 @@ Notes:
 
 - This is a core feature of any banking app, and is expected by users. It should be easily accessible from the home screen.
 
-Acceptance Criteria:
-
-- Given that I am a logged-in user, when I open the app, then I should see my account balance displayed prominently on the home screen.
+Acceptance Criteria: AC-1
   </user-story-example>
 
 This list of user stories should be extremely extensive and cover all aspects of the feature.
@@ -92,5 +102,18 @@ A description of the things that are out of scope for this PRD.
 ## Further Notes
 
 Any further notes about the feature.
+
+## Acceptance Criteria
+
+The single, machine-readable source of truth for what "done" means. Write this block in the shared canonical format defined in [`../../shared/acceptance-criteria.md`](../../shared/acceptance-criteria.md): a stable heading, sentinel comments, and one `AC-<n>` criterion per checkable behaviour. Every user story above references its criteria by id. `spec-to-tests` and `review-pr` read this exact block, so do not deviate from the grammar.
+
+<!-- acceptance-criteria:start format=gwt/v1 -->
+
+### AC-1: Account balance is shown on the home screen
+- **Given** a logged-in user
+- **When** the user opens the app
+- **Then** the account balance is displayed prominently on the home screen
+
+<!-- acceptance-criteria:end -->
 
 </prd-template>


### PR DESCRIPTION
## Why

Today `review-pr` eyeballs a diff against prose. This change makes acceptance criteria a first-class, machine-readable part of the spec and threads them through the three skills that produce and consume it, so "did we build what the spec asked" becomes a checkable result rather than an opinion — and an autonomous delivery factory gets an objective definition of done it can check itself.

Resolves the work described in #17.

## What

- **Shared format (the linchpin)** — `plugins/aimate/shared/acceptance-criteria.md` defines the one canonical grammar: a `## Acceptance Criteria` block wrapped in `<!-- acceptance-criteria:start format=gwt/v1 -->` / `end` sentinels, one criterion per stable `AC-<n>` id in Given/When/Then. The id is the join key across spec, tests, and review.
- **`write-prd`** — derives criteria during the interview, confirms them with the user, and ends every PRD with the canonical block. User stories reference criteria by id instead of restating them (single source of truth).
- **`spec-to-tests` (new skill)** — detects the repo's test framework (PHPUnit / Jest / Vitest / pytest / Go, degrades gracefully) and scaffolds one or more failing/pending stubs per criterion, each tagged with its `AC-<n>` id. Never fabricates a passing test.
- **`review-pr`** — adds a criteria-verification pass (Step 5) that locates the linked spec and reports, per id, whether the diff and its tests satisfy each criterion. An uncovered or unasserted criterion is a finding. Existing review lenses are untouched.
- **Docs** — plugin README gets an Acceptance Criteria Contract section and a `spec-to-tests` entry; root README threads the skill into the workflow; `plugin.json` → 1.4.0.

## Consistency

All three skills reference the one shared file — nothing hard-codes a second copy of the format. Verified the sentinel grammar and `AC-<n>` id scheme are identical across `write-prd`, `spec-to-tests`, `review-pr`, and the shared reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)