### PR TITLE
docs(README.md): Improved SDD instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ This is where teams add project-specific skills — e.g. a deployment agent, a m
 
 ## Spec-Driven Development Workflow
 
-`aimate` and its recommended external skills are designed to support a **spec-driven development** workflow: start with a well-defined specification, align on architecture, plan the work, then hand it off to a coding agent of your choosing. Throughout this repo, "spec" is shorthand for the PRD and the implementation plan together.
+`aimate` and its recommended external skills are designed to support a **spec-driven development** workflow: start with a well-defined specification, align on architecture, plan the work, then hand it off to a coding agent of your choosing. Throughout this section, "spec" refers loosely to the planning artifacts a change produces — chiefly the PRD (the what and why) and the implementation plan (the how). They share the same home and lifecycle in the repo, but they are distinct documents.
 
 The plugin intentionally does **not** include a pre-configured coding agent. Projects vary significantly in language, tooling, and conventions. It is expected that each team brings their own coding agent and project-specific skills on top of this shared foundation.
 
@@ -338,7 +338,7 @@ We work across Jira, GitLab issues, and GitHub depending on the client. The repo
 The common worry is that `docs/specs/` becomes a swamp of stale files. That happens when specs are treated as permanent documentation. They are not. A spec describes one change and stops being edited once that change ships. Documentation describes the system as it is now and lives forever. Keep the two apart, retire finished specs out of the active folder, and the working area stays lean.
 
 - **One spec, one change.** A spec covers a single ticket. Once it merges you stop editing it; the next change gets its own file. Every spec has a natural end.
-- **Keep it small.** A spec over roughly two pages is usually two tickets. If `write-prd` or  produces something enormous, split the work rather than writing a monster. Small specs are also the ones `scope-plan` and `review-pr` handle best.
+- **Keep the PRD small; keep the plan granular.** A PRD over roughly two pages is usually two tickets — if `write-prd` produces something sprawling, split the work rather than writing a monster. Plans are different: an atomic, dependency-mapped plan is legitimately long, so judge it by whether the tasks are small and the scope is still one ticket, not by page count. If a single spec covers so much that its plan balloons, that is a sign to split the ticket, not to trim the plan.
 - **Retire when the ticket is closed.** While the ticket is open the spec stays in `docs/specs/`, because a feature is often hardened or hotfixed after merge and the spec is still the live reference then. When the ticket is closed, move the spec to `docs/specs/done/` in a small cleanup PR. The active folder stays lean and the spec is kept, not thrown away.
 - **Do not curate `done/`.** It is a growing pile on purpose and nobody maintains it. It sits out of the active folder, so it does not clutter daily work, and it has a defined future use (see below).
 - **ADRs are not retired.** ADRs live in the repo like specs, but they stay put when the ticket closes. An architectural decision stays true after the change ships, so it is a durable record, not a disposable spec.
@@ -359,7 +359,7 @@ Nothing here asks you to do factory work today. Keep writing and retiring specs 
 - Is there a spec file for this work in `docs/specs/`?
 - Does the ticket link to it, rather than repeat it?
 - Does the spec describe what the diff actually does?
-- Is it small and about this one change, not a permanent doc in disguise?
+- Is the PRD focused on this one change, not a permanent doc in disguise, and is the scope still a single ticket?
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ The stages below describe the recommended workflow and which skills and MCP serv
 
 The three MCP servers bundled with `aimate` (Figma, GitLab, Atlassian) are available throughout the workflow. Skills that depend on an MCP server call it automatically — you do not need to invoke the MCP directly. See the [aimate plugin README](plugins/aimate/README.md#mcp-servers) for setup details. The only manual step required is generating a GitLab Personal Access Token the first time a GitLab skill is used.
 
+> [!NOTE]
+> [Spec-Driven Development](https://specdriven.ai/) is a methodology not yet solidified. See [Understanding Spec-Driven Development](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html)
+> We are learning and experiecing pratical implementation. For now aimate and following documenation assumes at least the first maturity level which is a spec-first development flow.
+
 ---
 
 ### Stage 1 — Explore & Challenge
@@ -247,7 +251,7 @@ The three MCP servers bundled with `aimate` (Figma, GitLab, Atlassian) are avail
 Before writing a line of spec, stress-test the problem statement and approach. Pull in existing Jira context documentation to ground the conversation.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `grilling` | [External](#grilling-mattpocockskills--grilling) | Relentlessly interview yourself on the problem, constraints, and assumptions until shared understanding is reached |
 | Atlassian MCP | aimate (bundled) | Read existing Jira tickets for background context before defining scope |
 
@@ -258,7 +262,7 @@ Before writing a line of spec, stress-test the problem statement and approach. P
 Translate the problem into a structured Product Requirements Document with user stories. Commit the PRD to the repo under `docs/specs/` and link the Jira ticket to that file — do not paste the PRD into the ticket. Reference designs from Figma and link back to the originating Jira issues. Optionally create a Jira ticket based on the PRD.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `write-prd` | aimate | Interview-driven PRD creation with codebase exploration and component sketching |
 | Figma MCP | aimate (bundled) | Inspect designs, read component specs, and pull design context directly into the PRD |
 | Atlassian MCP | aimate (bundled) | Read linked Jira issues for acceptance criteria, and link the ticket to the committed PRD file |
@@ -270,7 +274,7 @@ Translate the problem into a structured Product Requirements Document with user 
 Document key architectural decisions as ADRs — structured enough for a coding agent to implement without follow-up questions. Store ADRs in the repo alongside the spec; unlike PRDs and plans, ADRs are durable architectural records and are not retired.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `grilling` | [External](#grilling-mattpocockskills--grilling) | Stress-test architectural options before committing |
 | `adr-writing` | [External](#adr-writing-vercelai--adr-skill) | Write Architectural Decision Records in MADR format |
 
@@ -281,7 +285,7 @@ Document key architectural decisions as ADRs — structured enough for a coding 
 Break down the spec into an atomic, dependency-mapped implementation plan with effort estimates. Commit the plan alongside the PRD in the repo, and sync only the estimate and status back to Jira. Use the estimate for planning and sales.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `scope-plan` | aimate | Generate execution-ready implementation plan and time estimate |
 | Atlassian MCP | aimate (bundled) | Update Jira tickets with estimates and move issues into the sprint |
 
@@ -292,7 +296,7 @@ Break down the spec into an atomic, dependency-mapped implementation plan with e
 Hand off the result of the scope-plan or spec to your team's coding agent. This stage is intentionally left to each project team — choose the coding agent, model, and project-specific skills that fit your stack.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | Context7 MCP | [Recommended MCP](#context7-upstashcontext7) | Pull in up-to-date, version-specific library docs to prevent hallucinated APIs |
 | Figma MCP | aimate (bundled) | Reference component specs and design tokens when generating UI code |
 | GitLab MCP / Github MCP | aimate (bundled) | Create pull requests for changed code |
@@ -304,7 +308,7 @@ Hand off the result of the scope-plan or spec to your team's coding agent. This 
 Review the resulting code changes for correctness, quality, and security. The GitLab MCP / Github MCP is used automatically by `review-pr` to fetch the diff and post inline review comments.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `review-pr` | aimate | Comprehensive MR/PR review with inline comments and code fix suggestions — uses GitLab MCP to post directly on the MR |
 | `asvs-audit` | aimate | OWASP ASVS 5.0 Level 1 security audit with evidence-backed findings |
 | GitLab MCP / Github | aimate (bundled) | Fetch MR diff, read existing comments, and post structured review comments |
@@ -316,7 +320,7 @@ Review the resulting code changes for correctness, quality, and security. The Gi
 Produce a manual test guide and open the merge request. The GitLab MCP handles branch creation, push, and MR opening.
 
 | Tool | Source | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `test-pr-guide` | aimate | Step-by-step manual testing guide for a branch or MR |
 | `create-gitlab-mr` | aimate | Commit, push, and open a GitLab MR in one step — uses GitLab MCP under the hood |
 | GitLab MCP | aimate (bundled) | Create the remote branch, push commits, and open the MR with description and labels |

--- a/README.md
+++ b/README.md
@@ -232,11 +232,11 @@ This is where teams add project-specific skills — e.g. a deployment agent, a m
 
 ## Spec-Driven Development Workflow
 
-`aimate` and its recommended external skills are designed to support a **spec-driven development** workflow: start with a well-defined specification, align on architecture, plan the work, then hand it off to a coding agent of your choosing.
+`aimate` and its recommended external skills are designed to support a **spec-driven development** workflow: start with a well-defined specification, align on architecture, plan the work, then hand it off to a coding agent of your choosing. Throughout this repo, "spec" is shorthand for the PRD and the implementation plan together.
 
 The plugin intentionally does **not** include a pre-configured coding agent. Projects vary significantly in language, tooling, and conventions. It is expected that each team brings their own coding agent and project-specific skills on top of this shared foundation.
 
-The stages below describe the recommended workflow and which skills and MCP servers to use at each step.
+The stages below describe the recommended workflow and which skills and MCP servers to use at each step. Where specs live and what happens to them after a change ships is covered in [Where specs live](#where-specs-live) at the end of this section. In short: the spec is a file in the repo and the tracker links to it, never the other way round.
 
 The three MCP servers bundled with `aimate` (Figma, GitLab, Atlassian) are available throughout the workflow. Skills that depend on an MCP server call it automatically — you do not need to invoke the MCP directly. See the [aimate plugin README](plugins/aimate/README.md#mcp-servers) for setup details. The only manual step required is generating a GitLab Personal Access Token the first time a GitLab skill is used.
 
@@ -255,19 +255,19 @@ Before writing a line of spec, stress-test the problem statement and approach. P
 
 ### Stage 2 — Specify
 
-Translate the problem into a structured Product Requirements Document with user stories. Reference designs from Figma and link back to the originating Jira issues. And or create JIRA ticket based on the PRD.
+Translate the problem into a structured Product Requirements Document with user stories. Commit the PRD to the repo under `docs/specs/` and link the Jira ticket to that file — do not paste the PRD into the ticket. Reference designs from Figma and link back to the originating Jira issues. Optionally create a Jira ticket based on the PRD.
 
 | Tool | Source | Purpose |
 |---|---|---|
 | `write-prd` | aimate | Interview-driven PRD creation with codebase exploration and component sketching |
 | Figma MCP | aimate (bundled) | Inspect designs, read component specs, and pull design context directly into the PRD |
-| Atlassian MCP | aimate (bundled) | Read linked Jira issues for acceptance criteria and link the finished PRD back to the ticket |
+| Atlassian MCP | aimate (bundled) | Read linked Jira issues for acceptance criteria, and link the ticket to the committed PRD file |
 
 ---
 
 ### Stage 3 — Decide Architecture
 
-Document key architectural decisions as ADRs — structured enough for a coding agent to implement without follow-up questions.
+Document key architectural decisions as ADRs — structured enough for a coding agent to implement without follow-up questions. Store ADRs in the repo alongside the spec; unlike PRDs and plans, ADRs are durable architectural records and are not retired.
 
 | Tool | Source | Purpose |
 |---|---|---|
@@ -278,7 +278,7 @@ Document key architectural decisions as ADRs — structured enough for a coding 
 
 ### Stage 4 — Plan
 
-Break down the spec into an atomic, dependency-mapped implementation plan with effort estimates. Sync the outcome back to Jira. And use estimation for planning and sales.
+Break down the spec into an atomic, dependency-mapped implementation plan with effort estimates. Commit the plan alongside the PRD in the repo, and sync only the estimate and status back to Jira. Use the estimate for planning and sales.
 
 | Tool | Source | Purpose |
 |---|---|---|
@@ -320,6 +320,46 @@ Produce a manual test guide and open the merge request. The GitLab MCP handles b
 | `test-pr-guide` | aimate | Step-by-step manual testing guide for a branch or MR |
 | `create-gitlab-mr` | aimate | Commit, push, and open a GitLab MR in one step — uses GitLab MCP under the hood |
 | GitLab MCP | aimate (bundled) | Create the remote branch, push commits, and open the MR with description and labels |
+
+---
+
+### Where specs live
+
+The workflow above produces specs. This part covers where they are stored and what happens to them once a change ships. The rule that makes the whole thing work: **the spec is a file in the repo, and the tracker links to it — never the other way round.**
+
+We work across Jira, GitLab issues, and GitHub depending on the client. The repo is the only thing every project has in common, so the repo is where the spec belongs. That keeps the rule the same everywhere and puts the spec next to the code it describes.
+
+**In the repo:** the PRD and the plan, as markdown, under `docs/specs/<ticket-id>-<slug>.md` (or split into `.prd.md` and `.plan.md` when large). The ticket ID in the filename keeps the spec and the ticket traceable in both directions. They change in the same pull request as the code they drive, so a reviewer sees intent and implementation together.
+
+**In the tracker:** status, assignee, sprint, estimate, and discussion, plus one link to the spec file pinned to a commit. Link rather than paste the requirements in, so nobody ends up reading a stale copy instead of the real spec.
+
+#### A spec is not documentation, so the folder does not bloat
+
+The common worry is that `docs/specs/` becomes a swamp of stale files. That happens when specs are treated as permanent documentation. They are not. A spec describes one change and stops being edited once that change ships. Documentation describes the system as it is now and lives forever. Keep the two apart, retire finished specs out of the active folder, and the working area stays lean.
+
+- **One spec, one change.** A spec covers a single ticket. Once it merges you stop editing it; the next change gets its own file. Every spec has a natural end.
+- **Keep it small.** A spec over roughly two pages is usually two tickets. If `write-prd` or  produces something enormous, split the work rather than writing a monster. Small specs are also the ones `scope-plan` and `review-pr` handle best.
+- **Retire when the ticket is closed.** While the ticket is open the spec stays in `docs/specs/`, because a feature is often hardened or hotfixed after merge and the spec is still the live reference then. When the ticket is closed, move the spec to `docs/specs/done/` in a small cleanup PR. The active folder stays lean and the spec is kept, not thrown away.
+- **Do not curate `done/`.** It is a growing pile on purpose and nobody maintains it. It sits out of the active folder, so it does not clutter daily work, and it has a defined future use (see below).
+- **ADRs are not retired.** ADRs live in the repo like specs, but they stay put when the ticket closes. An architectural decision stays true after the change ships, so it is a durable record, not a disposable spec.
+- **Do not duplicate real docs.** If a fact is true beyond this one change, it belongs in a README or an architecture doc, and the spec links to it. Duplication is what "bloat" usually means.
+
+#### Why we keep retired specs
+
+While the change is being built, the spec is the truth about what we are building — what `scope-plan` estimates against, what `review-pr` checks, and what a second dev reads to understand what "done" means. That job ends when the ticket closes.
+
+Once the code merges, the truth about what the system *does* moves to the code itself, because the code is the running, tested answer. So we take the spec out of the active folder; as a live document it would start to mislead the moment the next change touches that area. But the spec still holds one thing the code never will: the *why*, including the alternatives that were rejected. That record has value beyond the change, which is why we keep it in `done/` rather than delete it.
+
+The real reason to preserve it is the delivery factory on our roadmap. An autonomous or semi-assisted delivery system needs intent and constraints at retrieval time, cheaply, without reconstructing them from a diff. A spec is the highest-quality "why" we ever capture about a change, written when it is true and tied to a commit, which makes the `done/` pile the natural corpus to seed the factory's memory layer later. Deleting specs today would destroy that corpus, and intent thrown away cannot be recovered. Git history technically keeps deleted files, but not as something you can point an ingestion job at; a `done/` folder is an enumerable dataset sitting ready.
+
+Nothing here asks you to do factory work today. Keep writing and retiring specs as described. Once a repo is onboarded into the factory, retiring will mean ingest into the memory layer and then remove from `done/`, and this section will be updated to say so.
+
+#### Quick checks before you merge
+
+- Is there a spec file for this work in `docs/specs/`?
+- Does the ticket link to it, rather than repeat it?
+- Does the spec describe what the diff actually does?
+- Is it small and about this one change, not a permanent doc in disguise?
 
 ---
 


### PR DESCRIPTION
SDD is important and we got some questions. 
Specs should be saved in repos, and while removing them when deployed is okay. The factory can use them to atuomatically pull them in memory.  
So adjusted the SDD text for everyone to use