### PR TITLE
fix: Claude Code plugin discovery on Windows (de-symlink manifests)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,1 +1,32 @@
-../marketplace.json
+{
+  "name": "aicelerate",
+  "owner": {
+    "name": "Dawn Technology",
+    "url": "https://github.com/Dawn-Technology"
+  },
+  "metadata": {
+    "description": "AI acceleration — plugin marketplace by Dawn Technology.",
+    "version": "1.0.1"
+  },
+  "plugins": [
+    {
+      "name": "aimate",
+      "description": "AI Automation teammate — reusable skills SDLC supporting; security auditing, GitLab workflow automation, and development planning.",
+      "version": "1.3.0",
+      "source": "./plugins/aimate",
+      "repository": "https://github.com/Dawn-Technology/aimate",
+      "license": "MIT",
+      "keywords": [
+        "security",
+        "owasp",
+        "asvs",
+        "gitlab",
+        "code-review",
+        "implementation-plan",
+        "product-requirements-document",
+        "user-stories",
+        "estimation"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/manifest-sync.yml
+++ b/.github/workflows/manifest-sync.yml
@@ -1,0 +1,29 @@
+name: Manifest sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "marketplace.json"
+      - ".claude-plugin/marketplace.json"
+      - "plugins/aimate/plugin.json"
+      - "plugins/aimate/.claude-plugin/plugin.json"
+      - "plugins/aimate/scripts/check_manifest_sync.py"
+  pull_request:
+    paths:
+      - "marketplace.json"
+      - ".claude-plugin/marketplace.json"
+      - "plugins/aimate/plugin.json"
+      - "plugins/aimate/.claude-plugin/plugin.json"
+      - "plugins/aimate/scripts/check_manifest_sync.py"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check Claude Code manifests are in sync
+        run: python plugins/aimate/scripts/check_manifest_sync.py

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ claude plugin install aimate@aicelerate
 ```
 
 > [!NOTE]
-> Compatibility is provided by symlinks (`.claude-plugin/marketplace.json` and `plugins/aimate/.claude-plugin/plugin.json`) that point at the Copilot-canonical manifests. Git stores these as symlinks on macOS and Linux. On Windows they only check out as symlinks when `git config core.symlinks` is `true`; otherwise they become plain text stubs and Claude Code discovery will fail.
+> Claude Code discovers the marketplace and plugin through `.claude-plugin/marketplace.json` and `plugins/aimate/.claude-plugin/plugin.json`. These are regular JSON files that mirror the Copilot-canonical manifests (`marketplace.json` and `plugins/aimate/plugin.json`); a CI check (`manifest-sync`) keeps each mirror identical to its source. They are plain files rather than symlinks so a checkout works on every platform, including Windows.
 
 ## Requirements
 

--- a/plugins/aimate/.claude-plugin/plugin.json
+++ b/plugins/aimate/.claude-plugin/plugin.json
@@ -1,1 +1,28 @@
-../plugin.json
+{
+  "name": "aimate",
+  "description": "AI Automation Teammate - SDLC Acceleration; reusable skills for security auditing, GitLab workflow automation, and development planning.",
+  "version": "1.3.0",
+  "author": {
+    "name": "Dawn Technology",
+    "url": "https://github.com/Dawn-Technology"
+  },
+  "repository": "https://github.com/Dawn-Technology/aicelerate/plugins/aimate",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "owasp",
+    "asvs",
+    "gitlab",
+    "github",
+    "code-review",
+    "scope-plan",
+    "planning",
+    "product-requirements-document",
+    "user-stories",
+    "estimation",
+    "wbso",
+    "wbso-aanvraag"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/aimate/scripts/check_manifest_sync.py
+++ b/plugins/aimate/scripts/check_manifest_sync.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fail if a Claude Code .claude-plugin manifest drifts from its canonical source.
+
+Claude Code discovers the marketplace and plugin via the .claude-plugin/*.json
+files. They must mirror the Copilot-canonical manifests exactly (by parsed JSON).
+They are committed as real files (not symlinks) so Windows checkouts work, which
+means nothing stops them drifting apart — this check does.
+"""
+import json
+import sys
+from pathlib import Path
+
+# (canonical source, Claude Code mirror), relative to repo root.
+PAIRS = [
+    ("marketplace.json", ".claude-plugin/marketplace.json"),
+    ("plugins/aimate/plugin.json", "plugins/aimate/.claude-plugin/plugin.json"),
+]
+
+
+def load(path: Path):
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[3]
+    failures = []
+    for canonical_rel, mirror_rel in PAIRS:
+        canonical, mirror = root / canonical_rel, root / mirror_rel
+        if not mirror.exists():
+            failures.append(f"{mirror_rel}: missing")
+            continue
+        try:
+            if load(canonical) != load(mirror):
+                failures.append(
+                    f"{mirror_rel}: out of sync with {canonical_rel} "
+                    f"(copy {canonical_rel} onto {mirror_rel})"
+                )
+            else:
+                print(f"OK: {mirror_rel} mirrors {canonical_rel}")
+        except json.JSONDecodeError as exc:
+            failures.append(f"{mirror_rel} or {canonical_rel}: invalid JSON ({exc})")
+
+    if failures:
+        print("\nMANIFEST SYNC FAILED:", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+    print("\nAll manifests in sync.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

The two manifests Claude Code uses for discovery were committed as git symlinks (mode `120000`):

- `.claude-plugin/marketplace.json` → `../marketplace.json`
- `plugins/aimate/.claude-plugin/plugin.json` → `../plugin.json`

On Windows with `core.symlinks=false` they check out as plain-text stubs containing the target path. Claude Code opens them expecting JSON, reads `../plugin.json`, fails to parse, and never registers the marketplace/plugin — so `/aimate:*` commands don't appear.

## Fix

- Commit the `.claude-plugin/` manifests as **regular JSON files** mirroring the canonical Copilot manifests (`mode change 120000 => 100644`).
- Add `plugins/aimate/scripts/check_manifest_sync.py` + a `manifest-sync` GitHub Actions workflow that fails when a mirror drifts from its canonical source (JSON-equality, robust to LF/CRLF). This takes over the drift-prevention the symlinks used to provide.
- Update the README compatibility note to describe the current state (real files kept in sync), dropping the obsolete symlink/`core.symlinks` caveat.

## Verification

- `git ls-files -s` shows `100644` for both manifests; staged blobs are real JSON, not path stubs.
- Sync check passes on the synced repo, exits non-zero on deliberate drift, passes again after restore.
- No `120000` manifest entries remain; no doc still promises symlinks.
- **Manual (reviewer, on Windows):** after this lands, install the marketplace from a fresh Windows checkout with `core.symlinks=false` and confirm `/aimate:*` commands appear in Claude Code.

Closes #21