### PR TITLE
Adding atomic commits skill

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -27,6 +27,21 @@
         "user-stories",
         "estimation"
       ]
+    },
+    {
+      "name": "atomicgit",
+      "description": "Skills for working with atomic commits — rebuilding branch history into small, logical, reviewable commits, and more.",
+      "version": "1.0.0",
+      "source": "./plugins/atomicgit",
+      "repository": "https://github.com/Dawn-Technology/aicelerate/plugins/atomicgit",
+      "license": "MIT",
+      "keywords": [
+        "git",
+        "commits",
+        "atomic-commits",
+        "history-rewrite",
+        "code-review"
+      ]
     }
   ]
 }

--- a/plugins/aimate/skills/reset-atomic-commits/SKILL.md
+++ b/plugins/aimate/skills/reset-atomic-commits/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: reset-atomic-commits
+description: Resets the current branch back to its merge-base with the default branch and rebuilds its history as a series of logical, reviewable atomic commits. DESTRUCTIVE — only invoke this skill when the user explicitly asks to "reset" the branch (or clearly equivalent wording, e.g. "reset en herbouw", "reset this branch into atomic commits"). Never invoke automatically for a generic request to "commit my changes", "split this into commits", or "clean up my commits" — those are not a reset request.
+metadata:
+  author: "Janne de Vos <janne.de.vos@dawn.tech>"
+  version: 1.0.0
+---
+
+# Reset Branch into Atomic Commits
+
+## Purpose
+
+Take everything that changed on the current branch relative to the default
+branch — regardless of how it is currently committed — and rebuild it from
+scratch as a small number of logical, atomic commits so a reviewer can review
+the branch commit-by-commit instead of as one large diff.
+
+## When to use this skill
+
+**Only** when the user's request explicitly uses the word "reset" (or an
+unambiguous synonym for discarding and rebuilding the branch's history —
+e.g. "herbouw de geschiedenis", "rewrite history from scratch"). Examples that
+qualify:
+
+- "Reset deze branch en bouw hem opnieuw op in atomic commits"
+- "Kun je de huidige branch resetten en herstructureren in logische commits"
+- "Reset this branch into atomic commits"
+
+Do **not** self-trigger this skill for adjacent-sounding but different
+requests — these are out of scope and must not cause an automatic reset:
+
+- "Commit my changes" / "maak hier een commit van"
+- "Split this diff into commits" (without "reset")
+- "Clean up my last commit" / "squash these commits"
+- "Write me a good commit message"
+
+If a request is ambiguous about whether a destructive reset is wanted, ask
+the user to confirm before proceeding — do not assume.
+
+## Guardrails
+
+- **Never run on the default/protected branch.** If the current branch is the
+  repo's default branch (or another obviously protected branch such as
+  `main`, `master`, `develop`, `release/*`), refuse and explain that this
+  skill only rewrites a feature branch.
+- **Always create a backup ref before any destructive operation.** Before
+  touching HEAD, create `backup/<branch>-<yyyymmdd-HHMMSS>` pointing at the
+  current tip, and tell the user it exists and how to recover
+  (`git reset --hard backup/<branch>-<timestamp>`).
+- **Never force-push, and never ask to push.** This skill only rewrites local
+  history. Pushing (force-with-lease) the rewritten branch is left entirely
+  to the user.
+- **Always present the commit plan and get explicit approval before
+  rewriting anything.** Do not perform the reset or create any commit until
+  the user has confirmed the plan.
+- Refuse (or double-check with the user) if the working tree is mid-merge,
+  mid-rebase, or has unresolved conflict markers — resolve that state first.
+- Never discard a backup ref (branch or tag) yourself without explicit,
+  per-run confirmation from the user — see Step 2.
+
+## Workflow
+
+### Step 1 — Verify preconditions
+
+1. Run `git status` and `git rev-parse --abbrev-ref HEAD` to confirm a clean
+   enough state (no in-progress merge/rebase/cherry-pick) and to get the
+   current branch name.
+2. Refuse if the current branch is the default branch or another protected
+   branch.
+3. Determine the repo's default branch: prefer
+   `git symbolic-ref refs/remotes/origin/HEAD` (strip `origin/`), falling
+   back to `git remote show origin` output, then to `main`/`master` if
+   neither resolves. Confirm the detected default branch with the user only
+   if it could not be determined unambiguously.
+
+### Step 2 — Compute scope, check for leftover backups, then create a new one
+
+1. Fetch the latest default branch ref: `git fetch origin <default-branch>`.
+2. Compute the merge-base: `git merge-base HEAD origin/<default-branch>`.
+3. Look for backup refs left over from previous runs of this skill on this
+   branch: `git for-each-ref refs/heads/backup/<branch>-* refs/tags/backup/<branch>-*`
+   (and, more broadly, `git for-each-ref refs/heads/backup/* refs/tags/backup/*`
+   in case the branch was renamed since).
+4. If any are found, list them to the user (name + commit date) and ask
+   whether they may be deleted. Only delete the specific ones the user
+   confirms — `git branch -D <ref>` or `git tag -d <ref>` as appropriate —
+   never delete a backup ref without that explicit confirmation, and never
+   delete one silently as part of a larger batch action.
+5. Create a fresh backup ref for this run: `git branch backup/<branch>-<timestamp> HEAD`.
+6. Show the user the full scope of what will be rebuilt:
+   `git diff <merge-base>..HEAD --stat` combined with any uncommitted
+   changes (`git status --porcelain`), so both already-committed work and
+   uncommitted work on top are accounted for.
+
+### Step 3 — Unpack the branch into one working diff
+
+1. `git reset --soft <merge-base>` — moves HEAD to the merge-base without
+   touching the working tree or index.
+2. `git reset` (mixed, no ref) — unstages everything, so the entire set of
+   changes (previously committed + anything that was uncommitted) now shows
+   up as one unstaged diff against the merge-base.
+3. Confirm nothing was lost: `git diff <merge-base> --stat` should match what
+   was shown in Step 2.4.
+
+### Step 4 — Determine the commit convention to use
+
+Look for repo-specific AI/commit-convention docs, in this order, and use the
+first one found instead of the default style below:
+
+- `commit-message.instructions.md` (repo root)
+- `CLAUDE.md` / `.claude/CLAUDE.md` (project-level, not the user's global one)
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `CONTRIBUTING.md` (only if it defines a commit message format)
+
+**Default style (used only if none of the above define a convention):**
+Conventional Commits, atomic per commit — `<type>(<scope>): <subject>`,
+imperative mood, one logical change per commit, short body explaining the
+*why* when the change isn't self-evident.
+
+### Step 5 — Plan the atomic commits
+
+Analyze the full diff from Step 3 and group hunks by **logical concern**, not
+by file and not by directory — the same way a developer would split a large
+change for review: e.g. "add feature X", "refactor Y to support X", "update
+tests for X", "update docs/config". A single file may end up split across
+multiple commits if it contains unrelated hunks; a single commit may span
+multiple files if they belong to the same concern.
+
+Order commits so the branch is buildable/reviewable at every step (e.g.
+foundational/shared code before the code that uses it, implementation before
+its tests, unless the convention found in Step 4 says otherwise).
+
+For each proposed commit, prepare:
+
+- The list of files/hunks it contains.
+- A draft commit message following the convention from Step 4.
+
+### Step 6 — Present the plan (HARD STOP)
+
+Show the user the full proposed commit plan: ordered list of commits, each
+with its files/hunks summary and full draft message. Ask for explicit
+confirmation before making any changes.
+
+Do **not** call any git write commands after presenting the plan in that same
+response. Wait for the user's next message.
+
+### Step 7 — Execute (only after confirmation)
+
+For each planned commit, in order:
+
+1. Stage exactly the files/hunks belonging to that commit — use
+   `git add <file>` when the whole file belongs to one commit, or
+   `git apply --cached` with an extracted hunk patch (or an interactive
+   `git add -p` selection) when a file's hunks are split across commits.
+2. Verify staged content matches the plan: `git diff --cached --stat`.
+3. Commit with the prepared message: `git commit -m "<message>"` (use a
+   heredoc or `-F` for multi-line/body messages).
+
+If reality doesn't quite match the plan once staging (e.g. a hunk can't be
+isolated cleanly), stop and tell the user rather than silently improvising a
+different split.
+
+### Step 8 — Report
+
+Show the rebuilt history (`git log --oneline <merge-base>..HEAD`) and remind
+the user:
+
+- The backup ref name, in case they want to recover the old history.
+- That the branch has **not** been pushed — if the branch previously existed
+  on the remote, a subsequent push will need `--force-with-lease`, which is
+  left to them.

--- a/plugins/atomicgit/README.md
+++ b/plugins/atomicgit/README.md
@@ -1,0 +1,27 @@
+# atomicgit
+
+Skills for working with atomic commits.
+
+Reusable skills for rebuilding, splitting, and reviewing git history so a branch stays reviewable commit-by-commit instead of as one large diff.
+
+## Skills
+
+### `commit-changes`
+
+> Writes a conventional commit message for the current changes and commits them.
+
+Figures out what's actually being committed (staged, or asks whether to stage the rest), drafts a message following the repo's convention (or Conventional Commits by default), and commits after a quick confirmation. Never rewrites existing commits — only ever adds one new commit on top of HEAD.
+
+**Trigger phrases:** "commit my changes", "commit this", "write me a commit message", "maak hier een commit van"
+
+---
+
+### `reset-atomic-commits`
+
+> Resets the current branch back to its merge-base with the default branch and rebuilds its history as a series of logical, reviewable atomic commits.
+
+Takes everything that changed on the current branch — regardless of how it is currently committed — and rebuilds it from scratch as a small number of logical, atomic commits. Creates a backup ref before touching any history, presents the full commit plan for approval, and never force-pushes.
+
+**DESTRUCTIVE** — only triggers on an explicit request to "reset" the branch (or a clear synonym), never on generic requests like "commit my changes" or "clean up my commits".
+
+**Trigger phrases:** "reset this branch into atomic commits", "reset en herbouw", "rewrite history from scratch"

--- a/plugins/atomicgit/plugin.json
+++ b/plugins/atomicgit/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "atomicgit",
+  "description": "Skills for working with atomic commits — rebuilding branch history into small, logical, reviewable commits, and more.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Dawn Technology",
+    "url": "https://github.com/Dawn-Technology"
+  },
+  "repository": "https://github.com/Dawn-Technology/aicelerate/plugins/atomicgit",
+  "license": "MIT",
+  "keywords": [
+    "git",
+    "commits",
+    "atomic-commits",
+    "history-rewrite",
+    "code-review"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/atomicgit/skills/commit-changes/SKILL.md
+++ b/plugins/atomicgit/skills/commit-changes/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: commit-changes
+description: Writes a conventional commit message for the current changes and commits them. Use for plain "commit my changes", "commit this", "write me a commit message", "maak hier een commit van" requests — everyday, non-destructive commits. Does NOT rewrite existing history or touch prior commits; for that, see reset-atomic-commits instead (only triggered by an explicit "reset" request).
+metadata:
+  author: "Janne de Vos <janne.de.vos@dawn.tech>"
+  version: 1.0.0
+---
+
+# Commit Changes
+
+## Purpose
+
+Turn the current working-tree changes into one well-formed, conventional
+commit: figure out what's actually being committed, draft a message that
+follows the repo's convention (or a sane default), get a quick confirmation,
+and commit.
+
+This is the everyday counterpart to `reset-atomic-commits`: it never rewrites
+existing commits or branch history, it only ever adds one new commit on top
+of HEAD.
+
+## When to use this skill
+
+Triggers on ordinary commit requests: "commit my changes", "commit this",
+"write me a commit message", "maak hier een commit van", "commit dit".
+
+Do **not** use this skill, and defer to `reset-atomic-commits` instead, when
+the request is about rewriting or restructuring commits that already exist
+(e.g. "reset this branch into atomic commits", "rebuild the history",
+"split my last 3 commits"). If unsure which the user wants, ask.
+
+If the pending changes clearly contain **multiple unrelated concerns** that
+don't belong in one commit, say so and suggest splitting them (either
+manually or via `reset-atomic-commits` if commits already exist) rather than
+silently writing one commit message that papers over a mixed diff.
+
+## Guardrails
+
+- Refuse (or double-check) if the working tree is mid-merge, mid-rebase, or
+  has unresolved conflict markers — resolve that first.
+- Never run `git add -A` / `git add .` silently. If nothing is staged, ask
+  whether to stage everything or only specific files — never guess.
+- Never amend, reset, or rewrite an existing commit. This skill only ever
+  creates one new commit on top of the current HEAD.
+- Never force-push, and never push at all unless the user explicitly asks.
+- Present the drafted message and ask for confirmation before running
+  `git commit`. A one-line "look good?" is enough — this isn't a destructive
+  operation, but it still changes the repo's history, so don't commit
+  silently on the user's behalf.
+- Don't add AI attribution trailers (e.g. "Generated with ...",
+  "Co-Authored-By: Claude") unless the repo's own convention (see Step 2)
+  calls for one, or the user explicitly asks for one.
+
+## Workflow
+
+### Step 1 — Determine what's being committed
+
+1. Run `git status` to see staged, unstaged, and untracked changes, and
+   confirm there's no in-progress merge/rebase/conflict.
+2. If changes are already staged (`git diff --cached --stat` is non-empty),
+   use exactly that as the commit scope — don't add anything else.
+3. If nothing is staged but the working tree has changes, ask the user
+   whether to stage everything or only specific files, then stage
+   accordingly.
+
+### Step 2 — Determine the commit message convention
+
+Look for repo-specific AI/commit-convention docs, in this order, and use the
+first one found instead of the default style below:
+
+- `commit-message.instructions.md` (repo root)
+- `CLAUDE.md` / `.claude/CLAUDE.md` (project-level, not the user's global one)
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `CONTRIBUTING.md` (only if it defines a commit message format)
+
+**Default style** (used only if none of the above define a convention): see
+[`../reset-atomic-commits/references/atomic-commits.md`](../reset-atomic-commits/references/atomic-commits.md)
+— Conventional Commits, `<type>(<scope>): <subject>`, imperative mood, short
+body explaining the *why* when it isn't obvious from subject + diff.
+
+### Step 3 — Check the diff is one logical concern
+
+Read the full staged diff. If it clearly mixes unrelated concerns (e.g. a
+bug fix plus an unrelated feature, or app code plus generated/vendored
+files that shouldn't ship together), tell the user what you see and ask
+whether to proceed as one commit anyway or split it first. Don't silently
+force a misleading single message onto a mixed diff.
+
+### Step 4 — Draft the message
+
+Write one commit message following the convention from Step 2. Show it to
+the user (message text + `git diff --cached --stat` as scope) and ask for
+confirmation.
+
+### Step 5 — Commit (only after confirmation)
+
+`git commit -m "<message>"` — use a heredoc or `-F` for a multi-line message
+with a body. Do not push.
+
+### Step 6 — Report
+
+Show `git log -1 --stat` so the user can see exactly what landed.

--- a/plugins/atomicgit/skills/reset-atomic-commits/SKILL.md
+++ b/plugins/atomicgit/skills/reset-atomic-commits/SKILL.md
@@ -113,10 +113,11 @@ first one found instead of the default style below:
 - `.github/copilot-instructions.md`
 - `CONTRIBUTING.md` (only if it defines a commit message format)
 
-**Default style (used only if none of the above define a convention):**
-Conventional Commits, atomic per commit — `<type>(<scope>): <subject>`,
-imperative mood, one logical change per commit, short body explaining the
-*why* when the change isn't self-evident.
+**Default style (used only if none of the above define a convention):** see
+[`./references/atomic-commits.md`](./references/atomic-commits.md) — Conventional
+Commits, atomic per commit — `<type>(<scope>): <subject>`, imperative mood,
+one logical change per commit, short body explaining the *why* when the
+change isn't self-evident.
 
 ### Step 5 — Plan the atomic commits
 
@@ -125,7 +126,9 @@ by file and not by directory — the same way a developer would split a large
 change for review: e.g. "add feature X", "refactor Y to support X", "update
 tests for X", "update docs/config". A single file may end up split across
 multiple commits if it contains unrelated hunks; a single commit may span
-multiple files if they belong to the same concern.
+multiple files if they belong to the same concern. See
+[`./references/atomic-commits.md`](./references/atomic-commits.md) for the
+full method and a self-check to apply before committing.
 
 Order commits so the branch is buildable/reviewable at every step (e.g.
 foundational/shared code before the code that uses it, implementation before

--- a/plugins/atomicgit/skills/reset-atomic-commits/references/atomic-commits.md
+++ b/plugins/atomicgit/skills/reset-atomic-commits/references/atomic-commits.md
@@ -1,0 +1,90 @@
+# Atomic Commits — Reference
+
+Background context for building commits, whether by an AI or a person. Use
+this to judge whether a proposed commit split is "atomic" enough before
+committing, and as the default convention when a repo defines none of its
+own (see `SKILL.md` Step 4).
+
+## What "atomic" means here
+
+A commit is atomic when it contains **exactly one logical change** and
+nothing else:
+
+- It can be described in one sentence without "and".
+- Reverting it cleanly undoes that one thing, no more, no less.
+- It doesn't mix unrelated concerns — e.g. a bug fix and an unrelated
+  formatting pass, or a new feature and a refactor it happened to need.
+- It's self-contained enough that `git bisect` lands on it and the reason
+  for the change is obvious from the diff plus the message.
+
+Atomic does **not** mean "small" — a single logical change can span many
+files (e.g. renaming a function and updating every call site). It also
+doesn't mean "one file" — a large file can rightfully contain hunks that
+belong to several different commits.
+
+## Why this matters more for AI-generated commits
+
+An AI building commits from a large diff tends toward two failure modes if
+not explicitly constrained:
+
+1. **One giant commit.** Fastest to produce, but useless for review —
+   reviewers can't approve or reject a `git bisect`-sized slice of it, and a
+   revert takes everything with it.
+2. **File-by-file commits.** Looks granular but isn't atomic — splitting by
+   file (or by directory) instead of by concern produces commits that don't
+   build, don't pass tests, or don't make sense in isolation, because a
+   single logical change is scattered across several of them.
+
+The fix in both cases is the same: group by **logical concern**, not by
+file, directory, or chronology of when the change was written.
+
+## How to split a diff into atomic commits
+
+1. **Read the whole diff first.** Don't start staging before you understand
+   everything that changed — a hunk that looks unrelated on its own often
+   turns out to belong to a concern you haven't identified yet.
+2. **Identify concerns**, e.g.:
+   - New capability (feature/endpoint/skill)
+   - Supporting/foundational change the above depends on (schema, shared
+     util, config)
+   - Bug fix (ideally isolated from feature work, even if found together)
+   - Tests for a concern above
+   - Docs/README/changelog for a concern above
+   - Unrelated cleanup (formatting, renames, dead code) — kept separate so
+     it doesn't obscure the functional diff
+3. **Order for buildability.** Each commit, applied in sequence, should
+   leave the branch in a state that at least compiles/builds — foundational
+   code before the code that uses it, implementation before its tests,
+   unless a project convention says otherwise.
+4. **One file, multiple commits is fine.** Use hunk-level staging
+   (`git add -p`, or a hand-built patch via `git apply --cached`) when a
+   file legitimately contains hunks from more than one concern. Don't force
+   a whole file into one commit just because splitting it is more work.
+5. **Say why, not just what.** The diff already shows *what* changed; the
+   message body should explain *why*, when it isn't obvious from the code
+   alone (e.g. why this approach, what it fixes, what it unblocks).
+
+## Message format
+
+Default when no repo convention is found (see `SKILL.md` Step 4 for the
+lookup order that overrides this):
+
+```
+<type>(<scope>): <subject>
+
+<optional body — the *why*, wrapped at ~72 cols>
+```
+
+- Type: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `build`,
+  `ci` (Conventional Commits).
+- Subject: imperative mood ("add", not "added"/"adds"), no trailing period.
+- Body: only when the reasoning isn't self-evident from subject + diff.
+
+## Quick self-check before committing
+
+- [ ] Can I describe this commit in one sentence without "and"?
+- [ ] Does reverting it undo exactly one thing?
+- [ ] Would the branch still build/pass tests if I stopped right after this
+      commit?
+- [ ] Is anything in here unrelated to the stated concern? (If yes, split
+      it out.)


### PR DESCRIPTION
Introduce a new skill to reset the current branch to its merge-base with the default branch and rebuild its history as atomic commits, ensuring a reviewable commit structure.