### PR TITLE
Standardise commit messages on one shared ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,29 +157,34 @@ Copilot won't infer Jira context from your codebase. Add this block manually so 
 - Allowed types: Taak, Story, Bug, Subtaak, Epic.
 ```
 
-### Commit Message Instructions
+### Commit Messages
 
-The repo ships a [`commit-message.instructions.md`](commit-message.instructions.md) file that defines a strict [Conventional Commits](https://www.conventionalcommits.org/) format with impact analysis and footer metadata. It is used in three ways:
+Commit messages come from the [`write-commit-message`](plugins/aimate/skills/write-commit-message/SKILL.md) skill. It ships with the plugin, so there is nothing to configure per project. The skill triggers on its own whenever a commit is being authored — when you ask ("commit this") and when an agent reaches `git commit` partway through a task. It reads the staged diff, picks up a Jira key from the branch name, drafts an imperative subject with a body explaining the observable problem and the approach taken, and commits.
 
-- **VS Code** — Copilot uses it automatically when generating commit messages via the Source Control panel.
-- **Copilot CLI agents** — Agents reference it when crafting commits, so the same standard applies whether you commit manually or via an automated skill.
-- **Skills and prompts** — Any skill that produces commits (e.g. `create-gitlab-mr`) can reference it explicitly to ensure consistent output.
+It runs autonomously: no approval step, no "shall I proceed", no questions about what to stage. It commits and then reports the SHA and the message it wrote. If something needs changing, `git commit --amend` is the fix.
 
-#### VS Code setup
+Skills that produce commits, such as `create-gitlab-mr`, delegate the message to this skill, so the same standard applies whether you commit by hand or through an automated workflow.
 
-Add the following to your project's `.vscode/settings.json` (or user `settings.json` to apply globally):
+#### One shared rules file
+
+The format itself — the seven rules, what belongs in each paragraph, the self-check, the worked examples — lives in a single maintained file: [`commit-message-rules.md`](plugins/aimate/skills/write-commit-message/references/commit-message-rules.md), inside the skill so it ships with the plugin. The skill reads it, and so does anything else that writes a commit message. Change the rules there and every path picks them up; nothing restates them.
+
+#### VS Code's Generate Commit Message button
+
+The button in the Source Control panel reads its instructions from a file and cannot invoke a skill, so it has its own entry point: [`commit-message.instructions.md`](commit-message.instructions.md). That file holds no rules of its own — it forwards to the shared rules, so the button and the skill produce the same message.
+
+Point the setting at both files. The button's generation call has no tools and cannot open a linked file, so the rules have to be in the prompt next to the instructions that reference them:
 
 ```json
 "github.copilot.chat.commitMessageGeneration.instructions": [
-    { "file": "commit-message.instructions.md" }
+    { "file": "commit-message.instructions.md" },
+    { "file": "plugins/aimate/skills/write-commit-message/references/commit-message-rules.md" }
 ]
 ```
 
-With this in place, the **Generate Commit Message** button in the Source Control panel will follow the Conventional Commits format defined in the file.
+Copilot chat and agent mode open the linked file themselves and need only the first entry.
 
-#### Copilot CLI and agents
-
-The file is automatically picked up by the Copilot CLI when it is present at the repo root. No extra configuration is required — agents will apply the commit conventions whenever they stage and commit changes.
+In another project, copy both files in and adjust the second path. Committing from chat avoids the copy entirely — `write-commit-message` reads the rules from the installed plugin, so it never goes stale.
 
 ### Tone of Voice
 
@@ -324,6 +329,7 @@ Produce a manual test guide and open the merge request. The GitLab MCP handles b
 | Tool | Source | Purpose |
 | --- | --- | --- |
 | `test-pr-guide` | aimate | Step-by-step manual testing guide for a branch or MR |
+| `write-commit-message` | aimate | Draft the commit message from the staged diff — triggers automatically on every commit |
 | `create-gitlab-mr` | aimate | Commit, push, and open a GitLab MR in one step — uses GitLab MCP under the hood |
 | GitLab MCP | aimate (bundled) | Create the remote branch, push commits, and open the MR with description and labels |
 

--- a/commit-message.instructions.md
+++ b/commit-message.instructions.md
@@ -1,103 +1,27 @@
-# Commit Message Guidelines
+# Commit Message Instructions
 
-## Core Principles
+Follow these instructions whenever you generate a git commit message.
 
-- **Clarity**: Messages must clearly explain _what_ changed and _why_.
-- **Security**: 🚫 NEVER include secrets, API keys, credentials, or PII in commit messages.
-- **Consistency**: Follow the Conventional Commits specification strictly.
+## Apply the shared rules
 
-## Format Structure
+The format is maintained in one file, and this file does not restate it:
 
-All commit messages MUST strictly follow this format:
+[`plugins/aimate/skills/write-commit-message/references/commit-message-rules.md`](plugins/aimate/skills/write-commit-message/references/commit-message-rules.md)
 
-```text
-<type>(<scope>)[!]: <subject>
-
-<body>
-
-<impact-analysis>
-
-<footer/metadata>
-```
-
-## 1. Header Line
-
-The header must be **72 characters or less**.
-
-For **Breaking Changes**, append `!` after the type/scope (e.g., `feat!: drop support for Node 12`) to signal a Major version bump.
-
-### Types
-
-Select the most specific type:
-
-- `feat`: 🚀 New feature (correlates with MINOR in semantic versioning)
-- `fix`: 🐛 Bug fix (correlates with PATCH in semantic versioning)
-- `docs`: 📚 Documentation changes
-- `style`: 💎 Code style/formatting (no logic change, whitespace, semi-colons)
-- `refactor`: 📦 Code refactoring (no functional change, no api change)
-- `perf`: ⚡ Performance improvements
-- `test`: 🚨 Adding or updating tests
-- `chore`: 🛠️ Maintenance tasks, dependencies, build scripts
-- `ci`: ⚙️ CI/CD configuration changes
-- `sec`: 🔒 Security fixes or improvements
-- `revert`: ⏪ Revert a previous commit
-
-### Scope (Optional)
-
-Use the affected module/component (folder) name (lowercase, kebab-case):
-
-- Core: `api`, `auth`, `data`, `utils`
-- Infra: `ci`, `config`, `deploy`, `scripts`
-- UI: `components`, `styles`, `views`, `assets`
-
-**Constraints**:
-
-- Select exactly **one** scope that best represents the primary change.
-- If a change touches more than two distinct scopes, omit the scope entirely or use `core`.
-- Do not use comma-separated scopes.
-
-### Subject
-
-- Use **imperative mood** ("Add feature" NOT "Added feature").
-- Capitalize the first letter.
-- Do not end with a period.
-- Be concise but descriptive.
-
-## 2. Body
-
-- **Mandatory** for all `feat`, `fix`, and complex `refactor` changes.
-- Separate from subject with a blank line.
-- Wrap lines at 72 characters.
-- Start with "This change..." to contextualize the description.
-- Explain the **motivation** for the change and contrast with previous behavior.
-- Use bullet points (`-`) for lists.
-
-## 3. Impact Analysis
-
-Instead of listing file changes, list significant side effects or impacts that may not be visible in the code diff.
-
-- **Migrations**: Database schema changes or data migrations?
-- **Deprecations**: Are any APIs or features deprecated?
-- **Dependencies**: New external libraries added?
-- **Configuration**: Changes to ENV variables or config files?
-
-## 4. Footer / Metadata
-
-- Reference issue tracker IDs explicitly (e.g., Jira, GitHub Issues).
-- Format: `Ref: #123` or `Fixes: ISSUE-123`.
-- Mention breaking changes if any: `BREAKING CHANGE: <description>\`.
-
-### Example
+Read that file and apply it in full — the format, the seven rules, what belongs in each paragraph, the self-check, and the worked examples. If it is not reachable from where you are running, read it from the raw source instead:
 
 ```text
-feat(auth): Add login rate limiting
-
-Implement rate limiting on the login endpoint to prevent brute
-force attacks. Users are now locked out after 5 failed attempts.
-
-Impact:
-- Configuration: Added `SECURITY_MAX_ATTEMPTS` to config.yaml
-- Security: Enforces 5-attempt limit per IP
-
-Ref: ISSUE-456
+https://raw.githubusercontent.com/Dawn-Technology/aicelerate/main/plugins/aimate/skills/write-commit-message/references/commit-message-rules.md
 ```
+
+## Writing the message
+
+- Ground the message in the staged diff. Describe what changed and why, never a file-by-file listing.
+- Output only the finished commit message — no headings, labels, prompt lines, commentary, or surrounding prose.
+- Take the ticket key from the branch name using the pattern `[A-Z]+-\d+` and put it on the last line. Omit that line entirely when the branch holds no key; never invent one.
+- Never start a line with `#` — git strips such lines under `--cleanup=strip`. Write `Ref: #123` instead of a bare `#123`.
+- Never include secrets, API keys, credentials, or PII.
+
+## Committing from chat or the CLI
+
+Use the `write-commit-message` skill instead. It reads the same rules file and also stages, commits, and reports the result.

--- a/marketplace.json
+++ b/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimate",
       "description": "AI Automation teammate — reusable skills SDLC supporting; security auditing, GitLab workflow automation, and development planning.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "source": "./plugins/aimate",
       "repository": "https://github.com/Dawn-Technology/aimate",
       "license": "MIT",
@@ -22,6 +22,7 @@
         "asvs",
         "gitlab",
         "code-review",
+        "commit-message",
         "implementation-plan",
         "product-requirements-document",
         "user-stories",

--- a/plugins/aimate/README.md
+++ b/plugins/aimate/README.md
@@ -42,11 +42,25 @@ Analyzes the diff, identifies what changed, and writes a guide a real person can
 
 ---
 
+### `write-commit-message`
+
+> Write a high-quality git commit message following the seven rules of great commit messages, and commit it.
+
+Reads the staged diff, picks up a Jira key from the branch name, and writes a message with an imperative subject and a body that explains the observable problem and the approach taken. It triggers on its own whenever a commit is being authored, including mid-task when an agent is about to run `git commit`, so you rarely have to ask for it by name.
+
+The skill is autonomous end to end — it drafts, commits, and reports the SHA and message afterwards. It never pauses for approval or asks what to stage; correct anything you dislike with `git commit --amend`.
+
+The format rules live in one shared file, [`references/commit-message-rules.md`](skills/write-commit-message/references/commit-message-rules.md) — maintain them there and every path picks them up. This skill reads it, the repo-root [`commit-message.instructions.md`](../../commit-message.instructions.md) that serves VS Code's Generate Commit Message button forwards to it, and every other skill that commits delegates to this skill.
+
+**Trigger phrases:** "commit this", "git commit", "write a commit message"
+
+---
+
 ### `create-gitlab-mr`
 
 > Creates a new feature branch from current git changes, commits them, pushes to the remote, and opens a GitLab Merge Request using the GitLab MCP server.
 
-Automates the full workflow from local changes to a published GitLab MR: creates a branch, stages and commits changes, pushes, and opens the MR — all in one step.
+Automates the full workflow from local changes to a published GitLab MR: creates a branch, stages and commits changes, pushes, and opens the MR — all in one step. The commit message itself comes from `write-commit-message`.
 
 **Trigger phrases:** "create a gitlab MR", "open a merge request", "push and create MR"
 

--- a/plugins/aimate/plugin.json
+++ b/plugins/aimate/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aimate",
   "description": "AI Automation Teammate - SDLC Acceleration; reusable skills for security auditing, GitLab workflow automation, and development planning.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Dawn Technology",
     "url": "https://github.com/Dawn-Technology"
@@ -15,6 +15,8 @@
     "gitlab",
     "github",
     "code-review",
+    "commit-message",
+    "write-commit-message",
     "scope-plan",
     "write-plan",
     "estimate-time",

--- a/plugins/aimate/skills/create-gitlab-mr/SKILL.md
+++ b/plugins/aimate/skills/create-gitlab-mr/SKILL.md
@@ -2,7 +2,7 @@
 name: create-gitlab-mr
 description: Creates a new feature branch from current git changes, commits them, pushes to the remote, and opens a GitLab Merge Request using the GitLab MCP server. Use this skill when asked to create a gitlab merge request
 metadata:
-  version: 1.0.1
+  version: 1.1.0
 ---
 
 # Create GitLab Merge Request from Current Changes
@@ -15,7 +15,7 @@ You are an expert Git and GitLab automation assistant. Your goal is to help user
 
 - Terminal access (`run_in_terminal`)
 - File reading capabilities (`read_file`) to check local references
-- Web fetching capabilities (`fetch_webpage`) to read external guidelines
+- The `write-commit-message` skill, which authors the commit message for this workflow
 - GitLab MCP server must be configured and authenticated
 
 ## Instructions
@@ -25,12 +25,14 @@ When the user asks you to create a branch, commit changes, and create a GitLab M
 1. **Analyze Current Changes**:
    - Run `git status`, `git diff`, and `git diff --staged` in the terminal to inspect what has changed.
    - Fetch the git remote using `git remote -v` to determine the project origin.
-   - Based on the changed files and their content, determine an appropriate branch name, a descriptive title for the Merge Request, and formulate a clear commit message.
-   - **Important:** When formatting the commit message, fetch and strictly follow the comprehensive guidelines from the online reference using the raw markdown link: `https://raw.githubusercontent.com/Dawn-Technology/aicelerate/main/commit-message.instructions.md`.
+   - Based on the changed files and their content, determine an appropriate branch name and a descriptive title for the Merge Request.
+   - **Important:** Do not write the commit message yourself. Invoke the **`write-commit-message`** skill and use the message it produces verbatim. It owns the commit message format, maintained in its `references/commit-message-rules.md`, and it runs autonomously — do not add an approval step of your own. Do not fetch `commit-message.instructions.md`; it is the VS Code entry point, forwarding to those same rules, which the skill already reads.
 
 2. **Create Branch, Commit, and Push**:
    - Use the `run_in_terminal` tool to checkout the new branch, stage the changes, commit, and push to origin.
-   - Example: `git checkout -b <branch-name> && git add . && git commit -m "<commit-message>" && git push -u origin <branch-name>`
+   - Create the branch and stage first: `git checkout -b <branch-name> && git add .`
+   - Then commit using the message file that `write-commit-message` produced, so its `#` prompt lines are stripped: `git commit --cleanup=strip -F <tmpfile>`. Never collapse a multi-line message into `git commit -m`.
+   - Finally: `git push -u origin <branch-name>`
 
 3. **Create the GitLab Merge Request**:
    - Call the `mcp_gitlab_create_merge_request` tool to open the MR on GitLab.

--- a/plugins/aimate/skills/write-commit-message/SKILL.md
+++ b/plugins/aimate/skills/write-commit-message/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: write-commit-message
+description: >
+  Writes high-quality git commit messages following the seven rules of great
+  commit messages (Chris Beams) and a fixed subject+body template. Auto-triggers
+  whenever a commit is being authored or suggested — e.g. the user asks to
+  "commit", "commit this", "git commit", or the agent itself is about to run
+  git commit — not only when explicitly asked to "write a commit message".
+  Runs autonomously: reads the staged diff, drafts the message, and commits
+  it without stopping for approval, then reports what was committed.
+metadata:
+  version: 1.0.0
+  author: "Johan Kromhout <johan.kromhout@dawn.tech>"
+---
+
+# Write commit message
+
+## Role
+
+You draft the **git commit message** any time a commit is being created —
+whether the user explicitly asks you to write one, or you (the agent) are
+about to run `git commit` as part of a task. Never skip this and never
+hand-wave a generic message like "fix stuff" or "update files".
+
+This skill owns the commit workflow: gather context, compose, commit, report.
+The **format rules themselves live in one shared file**,
+[`./references/commit-message-rules.md`](./references/commit-message-rules.md),
+which the repo-root `commit-message.instructions.md` forwards to as well.
+Maintain the rules there, never here.
+
+Other skills that produce commits (e.g. `create-gitlab-mr`) delegate the
+message to this skill instead of writing their own.
+
+## Autonomy
+
+Run end to end without a confirmation step. Draft the message, commit it, and
+report what was committed afterwards.
+
+- Never ask the user to approve, confirm, or review the draft before
+  committing, and never present a draft and wait.
+- Never ask which files to stage, whether to proceed, or which wording to
+  prefer. Decide, using the rules file and the diff, and commit.
+- No question is needed for anything this skill covers — every gap has a
+  default below. If something is genuinely unresolvable (e.g. the repository
+  has no commits and no identity configured), do the part you can and report
+  the blocker; do not stall waiting on an answer.
+- A user who wants to intervene will amend or reset afterwards. `git commit`
+  is cheap to redo; a blocked agent is not.
+
+## Persistence
+
+ACTIVE for every commit in this session, not just when explicitly requested.
+Applies even mid-task, e.g. right before running `git commit` as one step of
+a larger change.
+
+## Step 1 — Gather context
+
+1. Run `git diff --cached` to see the staged changes. This is the primary
+   source for _what_ changed.
+   - If nothing is staged, do not stop to ask. Read `git status --short` and
+     `git diff`, stage the changes that belong to the work at hand with
+     `git add <paths>` (or `git add -A` when the intent is to commit
+     everything), and continue. Name the files you staged in the report at
+     the end.
+   - Leave out anything obviously unrelated to the task — build output, local
+     scratch files, unrelated edits already in the tree. Skipping a file is a
+     decision you make silently; it is not a question for the user.
+2. Get the current branch: `git rev-parse --abbrev-ref HEAD`.
+3. Extract a Jira ticket key from the branch name using the pattern
+   `[A-Z]+-\d+` (e.g. `PROJ-156`, `ABC-1211`).
+   - If no key is found in the branch name, skip the ticket lookup and omit
+     the links line gracefully — do not block the commit on this.
+
+## Step 2 — Compose the message
+
+**Read [`./references/commit-message-rules.md`](./references/commit-message-rules.md) now and follow it.**
+It defines the format, the seven rules, what belongs in each paragraph, the
+symptom-not-mechanics requirement, the self-check, and the worked examples.
+Do not compose from memory.
+
+Use the template below as scaffolding while you write. The `#` lines are
+**prompts that guide you** — they are NOT part of the final commit. They must
+be stripped from the actual commit (git only strips them under
+`--cleanup=strip`; see Step 3). Never leave `#` lines visible in the committed
+message.
+
+```
+<subject line>
+
+# If applied, this commit will...
+<subject line's action, restated/completed if useful>
+
+# Why is this change needed?
+Prior to this change, <the problem / prior behavior, grounded in the diff and ticket context>
+
+# How does it address the issue?
+This change <the conceptual approach taken, and WHY this approach>
+
+# Provide links to any relevant tickets, articles or other resources
+<Jira ticket key/link if one was found — omit this line entirely if none>
+```
+
+Before committing, run the self-check from the rules file against your draft
+and fix what it catches. Its two failures — a subject that names code instead
+of an outcome, and a "how" that walks through the diff — are the ones that
+actually happen. This is your own check, not a round trip to the user.
+
+## Step 3 — Commit
+
+Commit straight away. Do not show the draft first and wait.
+
+- Commit so the `#` prompt lines are stripped: write the full template
+  (including `#` lines) to a temp file and commit with
+  **`git commit --cleanup=strip -F <tmpfile>`**, then delete the temp file.
+  Do NOT use `-F` without `--cleanup=strip` (default cleanup for `-F`/`-m` is
+  `whitespace`, which leaves the `#` lines in the commit). Verify afterwards
+  with `git show -s --format=%B <sha>` that no `#` lines remain.
+- `--cleanup=strip` drops **every** line starting with `#`, not only the
+  template prompts. If a body or links line would start with an issue
+  reference such as `#123`, rewrite it (`Ref: #123`) or move the reference
+  inline — otherwise it silently disappears from the commit.
+- When another skill drives the commit, hand it the temp file path and the
+  same `git commit --cleanup=strip -F <tmpfile>` invocation. Never let a
+  multi-line message be collapsed into `git commit -m`.
+
+## Step 4 — Report
+
+After committing, show the user what landed: the short SHA, the committed
+message as `git show -s --format=%B` returns it, and the files you staged if
+you staged anything yourself. This is a report of work done, not a request for
+approval — do not append a question to it.
+
+If the message needs changing, the fix is `git commit --amend`, not a
+pre-commit approval round.

--- a/plugins/aimate/skills/write-commit-message/references/commit-message-rules.md
+++ b/plugins/aimate/skills/write-commit-message/references/commit-message-rules.md
@@ -1,0 +1,185 @@
+# Commit Message Rules
+
+The single source of truth for commit message content and format at Dawn
+Technology. Maintain this file only — the `write-commit-message` skill and the
+repo-root `commit-message.instructions.md` (which serves VS Code's Generate
+Commit Message button) both point here rather than restating the rules.
+
+This file defines **what a good message says**. It does not describe how to
+gather the diff or run `git commit` — that workflow lives in the skill's
+`SKILL.md`.
+
+## Core principles
+
+- **Clarity**: the message explains _what_ changed and _why_.
+- **Security**: 🚫 NEVER include secrets, API keys, credentials, or PII.
+- **Consistency**: one format, everywhere. No Conventional Commits prefixes, no
+  type/scope, no emoji.
+
+## Format
+
+```text
+<subject line>
+
+<why: the problem or the prior behavior>
+
+<how: the conceptual approach taken, and why that approach>
+
+<ticket key, if there is one>
+```
+
+The structure lives in the paragraph order, not in markup. The finished message
+carries no section headings, labels, or prompt lines.
+
+## The seven rules
+
+1. **Separate subject from body with a blank line.**
+2. **Limit the subject line to ~50 characters** (72 is the hard cap; GitHub
+   truncates beyond that).
+3. **Capitalize the subject line.**
+4. **Do not end the subject line with a period.**
+5. **Use the imperative mood in the subject line** — it must complete the
+   sentence "If applied, this commit will \_\_\_" (e.g. "Refactor subsystem X
+   for readability", not "Fixed bug" or "Refactoring subsystem X").
+6. **Wrap the body at 72 characters.**
+7. **Use the body to explain _what_ and _why_, not _how_** — the diff already
+   shows how; the body's job is context that would otherwise be lost. This
+   applies to the "how does it address the issue?" paragraph too: describe the
+   approach and its rationale, not the code mechanics.
+
+## Subject line — write the SYMPTOM, not the mechanics
+
+The single most common failure is describing the **code** that changed instead
+of the **problem a human observed**. The subject must lead with the _user /
+operator / business-observable_ symptom or goal — what someone actually saw go
+wrong, or what capability was missing — **not** the classes, methods, columns,
+or internal nouns involved.
+
+Write it as if for a reader who has **never seen this code**. If the subject
+only makes sense to someone who knows the internals, rewrite it.
+
+Ban from the subject line: class names, method names (`extendDueDate()`), DB
+column names (`dueDate`), and internal jargon. Name the outcome instead.
+
+- ❌ `Fix invoice dueDate leaking payment window to frontend`
+  ← names a column and an internal concept; a reader can't tell what broke.
+- ✅ `Fix dashboard showing incorrect due date`
+
+## Body — why is this change needed?
+
+Open on the observable problem or the missing capability, never on a method,
+class, or column. Start with "Prior to this change, …" and describe the prior
+behavior, grounded in the diff and the ticket context. Implementation nouns may
+appear later, only where they clarify the symptom.
+
+- ❌ "Prior to this change, calling extendDueDate() on the Invoice entity
+  persisted a 99-day window directly onto the dueDate column." ← opens on a
+  method call and a column.
+- ✅ "Prior to this change, the dashboard showed the wrong due date — the
+  99-day payment-provider window instead of the customer's original 30-day
+  payment term. That window only exists to satisfy the provider's expiry
+  requirement; it was never meant to be shown to the customer."
+
+## Body — how does it address the issue?
+
+Start with "This change …" and describe the **conceptual approach** and the
+**reasoning behind it**: what strategy solves the problem, why it was chosen
+over the alternatives, and any consequences or trade-offs.
+
+This is **not** a technical walkthrough of the code. The diff already shows
+which classes were added, which methods, the retry logic, the env var names.
+Repeating that is wasted effort and rots as the code changes. A future reader
+has the diff for the _how_; they read the message for the _why_ behind the
+approach.
+
+- ✅ "Introduces a shared, reusable client so future Salesforce objects and
+  triggers can hook in without re-implementing auth and error handling.
+  Wiring a concrete caller is deliberately deferred to a follow-up ticket."
+- ❌ "Adds SalesforceAuthenticator (OAuth2 client-credentials with cached
+  token), SalesforceClient (create/upsert/get with one-time 401 retry and a
+  typed SalesforceApiException), and CaseClient. Reads env vars
+  SALESFORCE_URL/CLIENT_ID/CLIENT_SECRET…" ← this is the diff's job, not the
+  commit message's.
+
+## Links
+
+Close with the ticket key on its own line — a bare key such as `PROJ-429`, or a
+full URL where the tracker needs one. Extract the key from the branch name
+using the pattern `[A-Z]+-\d+` (e.g. `PROJ-156`, `ABC-1211`).
+
+If the branch name holds no key, omit the line entirely. Never invent a key,
+and never block a commit on a missing one.
+
+Do not start any line with `#`. Under `git commit --cleanup=strip` every such
+line is removed from the message, so an issue reference written as `#123` at
+the start of a line silently disappears. Write `Ref: #123` instead, or keep the
+reference inline.
+
+## Be terse
+
+Good messages are short. The worked examples below are 2–5 lines of body — some
+are two sentences. Do not pad. Say the symptom, say the approach, stop.
+
+## Self-check before the message is final
+
+- Could a reader who has **never seen this code** understand, from the
+  **subject alone**, what changed for them? If it only makes sense to someone
+  who knows the internals, rewrite it.
+- Does the **first sentence of the body** describe an observable problem or a
+  missing capability — _not_ a method, class, or column? If it opens on code,
+  rewrite it.
+- Is there a class, method, or column name in the subject line? Remove it.
+- Does the message contain a secret, key, credential, or PII? Remove it.
+
+## Worked examples
+
+Real, approved messages, shown exactly as committed.
+
+```text
+Send billing notifications
+
+Prior to this change, no billing notifications were sent to customers,
+so they would not be triggered to update their company info and/or
+enable/disable automatic subscription renewal.
+
+This change sends notification emails to all users of a company 6 weeks
+prior to the subscription expiring. The mails are sent after 5 am.
+
+PROJ-218
+```
+
+```text
+Link added users to their company
+
+Prior to this change, added users were dangling.
+
+This change properly links users to the company.
+
+PROJ-105
+```
+
+```text
+Expose company name for read-only user
+
+Prior to this change, the dashboard could not show the company name
+of the read-only user, because that user cannot fetch other companies
+(as intended).
+
+This change exposes the name directly on the profile response.
+```
+
+```text
+Fix dashboard showing incorrect due date
+
+Prior to this change, the dashboard showed the wrong due date — the
+99-day payment-provider window instead of the customer's original
+30-day payment term. That window only exists to satisfy the provider's
+expiry requirement; it was never meant to be shown to the customer.
+
+This change treats the payment-provider window as a provider concern
+computed at request time, rather than a fact stored on the invoice. The
+invoice's due date is no longer mutated, so the customer always sees the
+original term while the provider still receives its required window.
+
+PROJ-429
+```


### PR DESCRIPTION
Prior to this change, the commit message standard lived only in a file at the repo root, and an agent that needed it fetched that file over the network at commit time. Nothing tied the standard to the tooling that writes commits, so a message written in VS Code and one written by an agent followed different conventions.

This change makes a single rules file the one definition every path reads, and adds a skill that owns the commit workflow around it. The VS Code entry point stays where it is and forwards to those same rules, so the wording is identical wherever a message is written and the rules are edited in one place.