### PR TITLE
New skill - write-summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Produce a manual test guide and open the merge request. Local Git handles branch
 | Tool | Source | Purpose |
 | --- | --- | --- |
 | `test-pr-guide` | aimate | Step-by-step manual testing guide for a branch or MR |
+| `write-summary` | aimate | Short and long plain-language descriptions of a branch, PR/MR, commit range, patch, or local changes |
 | `write-commit-message` | aimate | Draft the commit message from the staged diff — triggers automatically on every commit |
 | `create-gitlab-mr` | aimate | Commit, push, and open a GitLab MR in one step through `glab` |
 | `glab` | Installed and authenticated locally | Open the MR with description and labels after local Git pushes the branch |

--- a/marketplace.json
+++ b/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "aimate",
       "description": "AI Automation teammate — reusable SDLC skills for security auditing, repository workflows, integration setup, and development planning.",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "source": "./plugins/aimate",
       "repository": "https://github.com/Dawn-Technology/aimate",
       "license": "MIT",
@@ -30,7 +30,8 @@
         "ticket-readiness",
         "product-requirements-document",
         "user-stories",
-        "estimation"
+        "estimation",
+        "write-summary"
       ]
     }
   ]

--- a/plugins/aimate/README.md
+++ b/plugins/aimate/README.md
@@ -98,6 +98,16 @@ Analyzes the diff, identifies what changed, and writes a guide a real person can
 
 ---
 
+### `write-summary`
+
+> Explain a branch, pull request, commit range, patch, or local changes in plain language.
+
+Reads the change set together with its task context and returns a short version and a concise expanded version in chat. It focuses on purpose, changed behavior, and user-facing or system-level outcomes without exposing implementation identifiers. The workflow is read-only and never publishes or updates anything.
+
+**Trigger phrases:** "summarize this branch", "describe these changes", "write a code change summary", "give me short and long versions"
+
+---
+
 ### `write-commit-message`
 
 > Write a high-quality git commit message following the seven rules of great commit messages, and commit it.

--- a/plugins/aimate/RELEASE_NOTES.md
+++ b/plugins/aimate/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 2.5.0
+
+Added `write-summary`, a read-only skill that turns a branch, pull request, merge request, commit range, patch, or local change set into short and long plain-language descriptions. It combines the diff with the supplied task context, focuses on purpose and observable outcomes, avoids implementation identifiers and marketing language, and only returns the result in chat.
+
 ## 2.4.0
 
 Added `validate-ticket`, which decides whether one ticket is ready for development and rewrites its description into a brief an agent can build from. It supports Jira work items, GitHub Issues, and GitLab Issues through the saved provider route, and a ticket pasted as plain text when no tracker is reachable. Every provider difference — identifier parsing, field mapping, Jira custom-field discovery, and the ADF/wiki formatting trap on a description write — lives in `references/provider-operations.md` rather than in the workflow.

--- a/plugins/aimate/plugin.json
+++ b/plugins/aimate/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aimate",
   "description": "AI Automation Teammate - SDLC acceleration with reusable skills for security auditing, repository workflows, integration setup, and development planning.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {
     "name": "Dawn Technology",
     "url": "https://github.com/Dawn-Technology"
@@ -30,7 +30,8 @@
     "estimation",
     "wbso",
     "wbso-aanvraag",
-    "write-readme"
+    "write-readme",
+    "write-summary"
   ],
   "skills": "./skills/"
 }

--- a/plugins/aimate/skills/write-summary/SKILL.md
+++ b/plugins/aimate/skills/write-summary/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: write-summary
+description: Summarize a branch, pull request, merge request, commit range, patch, or local code changes in plain language. Use when the user asks for a branch summary, code change summary, change description, or short and long descriptions of completed development work.
+metadata:
+    author: "Piotr Ramotowski <piotr.ramotowski@dawn.tech>"
+    version: 1.0.0
+---
+
+# Write Summary
+
+Explain the purpose and outcomes of a bounded set of code changes. Produce text a person can understand without reading the diff.
+
+This is a read-only skill. Inspect the available context, then reply in chat. Do not edit files, commit, push, open or update a pull request or merge request, post comments, or publish the result anywhere.
+
+## Resolve the scope
+
+Honor an explicitly supplied change set, comparison target, and task description first. Supported inputs include:
+
+- the current branch compared with its target branch;
+- a pull request or merge request and its description;
+- a commit or commit range;
+- staged, unstaged, or other local changes;
+- a supplied diff or patch.
+
+For a local branch, determine the target from explicit context, pull-request metadata, the remote default branch, or repository conventions, in that order. Compare from the merge base so unrelated target-branch changes are excluded. Do not silently include uncommitted work in a committed branch summary; include it only when the request covers local or unfinished changes.
+
+Use read-only provider tooling when a pull-request or merge-request URL is the only source. Never turn a summary request into a provider write action.
+
+If the requested scope cannot be determined or read, state exactly what context is missing instead of guessing.
+
+## Understand the change
+
+Read the complete diff and the supplied task, ticket, or change description. Inspect nearby code or documentation only when needed to translate the diff into observable behavior.
+
+Determine:
+
+- the problem or objective;
+- what capability or behavior was added, changed, fixed, removed, or improved;
+- who or what is affected;
+- the user-facing or system-level outcome;
+- any important boundary on the outcome that prevents an overstatement.
+
+Treat the diff as evidence of what changed and the task description as context for why. Reconcile the two; do not repeat claims that the changes do not support. When the reason is not evidenced, describe the verified outcome without inventing a motive.
+
+## Write the summaries
+
+Return exactly these two sections unless the user requests a different format:
+
+```markdown
+## Short version
+
+[One or two direct sentences.]
+
+## Long version
+
+[One concise paragraph with enough context to explain the purpose, changed behavior, and outcome.]
+```
+
+Both versions must stand on their own. The long version expands the short version; it does not become a file-by-file inventory.
+
+Apply these rules to both versions:
+
+- Lead with what changed and why it matters.
+- Describe outcomes and behavior, not the implementation sequence.
+- Use plain language and concrete verbs.
+- Mention both user-facing and system-level effects when both are material.
+- If the work is entirely internal, explain its operational effect without pretending it adds user-visible functionality.
+- Avoid class names, method or function names, file paths, configuration keys, database fields, and technical variable names.
+- Avoid commit-by-commit narration, diff statistics, exhaustive lists, and test details unless the user explicitly asks for them.
+- Avoid marketing language, filler, praise, and vague claims such as "enhanced," "seamless," "robust," or "cutting-edge."
+- Do not begin with process commentary such as "I reviewed the branch" or end with an offer to publish the text.
+
+Before replying, verify that every material claim is supported by the change set or supplied context, that no implementation identifier leaked into the prose, and that the short and long versions differ meaningfully in depth.


### PR DESCRIPTION
Added a summary writing workflow for branches, pull requests, commit ranges, patches, and local changes. 
It combines the change set with the task context to explain the purpose, affected behavior, and user-facing or system-level outcome without exposing implementation details. 

The workflow only responds in chat and cannot modify code or publish results. Plugin documentation and metadata now include the new capability.